### PR TITLE
Render the resume from local JSON Resume data

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,25 +4,23 @@ import { Tooltip } from 'react-tooltip';
 import StartMenu from './components/StartMenu.jsx';
 import LandscapeBg from './components/LandscapeBg.jsx';
 import Grid from './components/Grid.jsx';
+import Resume from './components/Resume.jsx';
 import { TOOLTIP_ID } from './constants.js';
 import logo from './assets/img/lucasrasmussen-logo.svg';
 import styles from './App.module.scss';
 import 'react-tooltip/dist/react-tooltip.css';
 
-const RESUME_URL = '//registry.jsonresume.org/redlucas';
-
 export default function App() {
   const [expanded, setExpanded] = useState(false);
-  const [resumeUrl, setResumeUrl] = useState(null);
-  const [resumeReady, setResumeReady] = useState(false);
+  const [showResume, setShowResume] = useState(false);
 
   // Clicking the start button grows the modal via a CSS transition. Only once
-  // that transition has finished do we swap the logo out for the resume
-  // iframe, so the iframe never renders at the small logo size. `transition:
-  // all` fires one event per animated property; re-setting the same URL is a
-  // no-op in React, so the extra events are harmless.
+  // that transition has finished do we swap the logo out for the resume, so it
+  // never renders at the small logo size. `transition: all` fires one event per
+  // animated property; re-setting the same value is a no-op in React, so the
+  // extra events are harmless.
   const handleTransitionEnd = () => {
-    if (expanded) setResumeUrl(RESUME_URL);
+    if (expanded) setShowResume(true);
   };
 
   return (
@@ -32,13 +30,8 @@ export default function App() {
         className={`${styles.modal} ${expanded ? styles.resume : styles.logo}`}
         onTransitionEnd={handleTransitionEnd}
       >
-        {resumeUrl ? (
-          <iframe
-            title="Resume"
-            src={`${resumeUrl}?theme=flat`}
-            className={resumeReady ? undefined : styles.hidden}
-            onLoad={() => setResumeReady(true)}
-          />
+        {showResume ? (
+          <Resume />
         ) : (
           <img className={styles.pulser} src={logo} alt="Lucas Rasmussen" />
         )}

--- a/src/App.module.scss
+++ b/src/App.module.scss
@@ -42,11 +42,26 @@
   }
 }
 
+// Sizing the sheet as a share of the viewport just inherits the display's
+// shape — a 16:9 letterbox on a monitor, a sliver on a phone. Give it its own
+// proportions instead, capped on both axes.
+//
+// Portrait and narrow screens: a sheet filling most of the display.
 .resume {
   border-radius: 15px;
-  min-width: 80vw;
+  width: min(94vw, 38rem);
+  height: min(90vh, 52rem);
   max-width: 100%;
-  min-height: 80vh;
+}
+
+// Given room to spread, it becomes a document window rather than a tall sheet.
+// The middle term caps width against height, so a short landscape window
+// stretches into a letterbox no more than a wide one does.
+@media (min-aspect-ratio: 1 / 1) {
+  .resume {
+    width: min(90vw, calc(86vh * 1.7), 68rem);
+    height: min(86vh, 46rem);
+  }
 }
 
 .pulser {

--- a/src/App.module.scss
+++ b/src/App.module.scss
@@ -24,17 +24,6 @@
   align-items: center;
   overflow: hidden;
 
-  iframe {
-    position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    border: none;
-  }
-
   > img {
     border-radius: 50%;
   }
@@ -58,12 +47,6 @@
   min-width: 80vw;
   max-width: 100%;
   min-height: 80vh;
-}
-
-// Keeps the iframe in the layout while it loads so it can fire `onLoad`,
-// but hidden until it has something to show.
-.hidden {
-  visibility: hidden;
 }
 
 .pulser {

--- a/src/components/Resume.jsx
+++ b/src/components/Resume.jsx
@@ -1,0 +1,150 @@
+import resume from '../data/resume.json';
+import styles from './Resume.module.scss';
+
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+// JSON Resume dates are ISO-ish (YYYY or YYYY-MM); an absent end date means
+// the role is current.
+function formatDate(value) {
+  if (!value) return 'Present';
+  const [year, month] = value.split('-');
+  return month ? `${MONTHS[Number(month) - 1]} ${year}` : year;
+}
+
+function Chips({ items }) {
+  return (
+    <ul className={styles.chips}>
+      {items.map((item) => (
+        <li key={item} className={styles.chip}>{item}</li>
+      ))}
+    </ul>
+  );
+}
+
+function Section({ label, children }) {
+  return (
+    <section className={styles.section}>
+      <h2 className={styles.eyebrow}>{label}</h2>
+      {children}
+    </section>
+  );
+}
+
+export default function Resume() {
+  const { basics, work, education, skills, languages, meta } = resume;
+  const { city, region } = basics.location;
+  // JSON Resume has no conferences section and closes the root to unknown
+  // keys, so `meta` is the spec's sanctioned place for it.
+  const conferences = meta.conferences;
+
+  const skillGroups = skills.filter((skill) => skill.keywords?.length);
+  const skillNotes = skills.filter((skill) => skill.level);
+
+  return (
+    <article className={styles.paper} tabIndex={0} aria-label={`Résumé — ${basics.name}`}>
+      <div className={styles.sheet}>
+        <header className={styles.header}>
+          <h1 className={styles.name}>{basics.name}</h1>
+          <p className={styles.label}>{basics.label}</p>
+          <p className={styles.meta}>{[city, region].filter(Boolean).join(', ')}</p>
+        </header>
+
+        <Section label="Summary">
+          <p className={styles.summary}>{basics.summary}</p>
+        </Section>
+
+        <Section label="Skills">
+          <div className={styles.skillGroups}>
+            {skillGroups.map((group) => (
+              <div key={group.name} className={styles.skillGroup}>
+                <h3 className={styles.skillName}>{group.name}</h3>
+                <Chips items={group.keywords} />
+              </div>
+            ))}
+          </div>
+          {skillNotes.length > 0 && (
+            <dl className={styles.notes}>
+              {skillNotes.map((note) => (
+                <div key={note.name} className={styles.note}>
+                  <dt className={styles.noteTerm}>{note.name}</dt>
+                  <dd className={styles.noteDesc}>{note.level}</dd>
+                </div>
+              ))}
+            </dl>
+          )}
+        </Section>
+
+        <Section label="Experience">
+          <div className={styles.entries}>
+            {work.map((job) => (
+              <article key={`${job.name}-${job.startDate}`} className={styles.entry}>
+                <div className={styles.entryHead}>
+                  <h3 className={styles.role}>{job.position}</h3>
+                  <span className={styles.dates}>
+                    {formatDate(job.startDate)} – {formatDate(job.endDate)}
+                  </span>
+                </div>
+                <p className={styles.org}>
+                  {job.name}
+                  {job.location && <span className={styles.orgLocation}>{job.location}</span>}
+                </p>
+                {job.highlights?.length > 0 && (
+                  <ul className={styles.highlights}>
+                    {job.highlights.map((highlight) => (
+                      <li key={highlight}>{highlight}</li>
+                    ))}
+                  </ul>
+                )}
+                {job.keywords?.length > 0 && <Chips items={job.keywords} />}
+              </article>
+            ))}
+          </div>
+        </Section>
+
+        <Section label="Education">
+          <div className={styles.entries}>
+            {education.map((school) => (
+              <article key={school.institution} className={styles.entry}>
+                <div className={styles.entryHead}>
+                  <h3 className={styles.role}>{school.institution}</h3>
+                  <span className={styles.dates}>
+                    {formatDate(school.startDate)} – {formatDate(school.endDate)}
+                  </span>
+                </div>
+                <p className={styles.org}>
+                  {school.studyType}
+                  {school.area && <span className={styles.orgLocation}>{school.area}</span>}
+                </p>
+              </article>
+            ))}
+          </div>
+        </Section>
+
+        <div className={styles.split}>
+          <Section label="Languages">
+            <dl className={styles.notes}>
+              {languages.map((entry) => (
+                <div key={entry.language} className={styles.note}>
+                  <dt className={styles.noteTerm}>{entry.language}</dt>
+                  <dd className={styles.noteDesc}>{entry.fluency}</dd>
+                </div>
+              ))}
+            </dl>
+          </Section>
+
+          <Section label="Conferences">
+            <ul className={styles.conferences}>
+              {conferences.map((conference) => (
+                <li key={`${conference.name}-${conference.year}`}>
+                  <span className={styles.conferenceName}>{conference.name}</span>
+                  <span className={styles.dates}>{conference.year}</span>
+                  <span className={styles.conferencePlace}>{conference.location}</span>
+                </li>
+              ))}
+            </ul>
+          </Section>
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/src/components/Resume.jsx
+++ b/src/components/Resume.jsx
@@ -30,6 +30,22 @@ function Section({ label, children }) {
   );
 }
 
+function Entry({ title, dates, subtitle, detail, children }) {
+  return (
+    <article className={styles.entry}>
+      <div className={styles.entryHead}>
+        <h3 className={styles.role}>{title}</h3>
+        <span className={styles.dates}>{dates}</span>
+      </div>
+      <p className={styles.org}>
+        {subtitle}
+        {detail && <span className={styles.orgDetail}>{detail}</span>}
+      </p>
+      {children}
+    </article>
+  );
+}
+
 export default function Resume() {
   const { basics, work, education, skills, languages, meta } = resume;
   const { city, region } = basics.location;
@@ -49,100 +65,95 @@ export default function Resume() {
           <p className={styles.meta}>{[city, region].filter(Boolean).join(', ')}</p>
         </header>
 
-        <Section label="Summary">
-          <p className={styles.summary}>{basics.summary}</p>
-        </Section>
+        <div className={styles.columns}>
+          <div className={styles.main}>
+            <Section label="Summary">
+              <p className={styles.summary}>{basics.summary}</p>
+            </Section>
 
-        <Section label="Skills">
-          <div className={styles.skillGroups}>
-            {skillGroups.map((group) => (
-              <div key={group.name} className={styles.skillGroup}>
-                <h3 className={styles.skillName}>{group.name}</h3>
-                <Chips items={group.keywords} />
+            <Section label="Experience">
+              <div className={styles.entries}>
+                {work.map((job) => (
+                  <Entry
+                    key={`${job.name}-${job.startDate}`}
+                    title={job.position}
+                    dates={`${formatDate(job.startDate)} – ${formatDate(job.endDate)}`}
+                    subtitle={job.name}
+                    detail={job.location}
+                  >
+                    {job.highlights?.length > 0 && (
+                      <ul className={styles.highlights}>
+                        {job.highlights.map((highlight) => (
+                          <li key={highlight}>{highlight}</li>
+                        ))}
+                      </ul>
+                    )}
+                    {job.keywords?.length > 0 && <Chips items={job.keywords} />}
+                  </Entry>
+                ))}
               </div>
-            ))}
+            </Section>
           </div>
-          {skillNotes.length > 0 && (
-            <dl className={styles.notes}>
-              {skillNotes.map((note) => (
-                <div key={note.name} className={styles.note}>
-                  <dt className={styles.noteTerm}>{note.name}</dt>
-                  <dd className={styles.noteDesc}>{note.level}</dd>
-                </div>
-              ))}
-            </dl>
-          )}
-        </Section>
 
-        <Section label="Experience">
-          <div className={styles.entries}>
-            {work.map((job) => (
-              <article key={`${job.name}-${job.startDate}`} className={styles.entry}>
-                <div className={styles.entryHead}>
-                  <h3 className={styles.role}>{job.position}</h3>
-                  <span className={styles.dates}>
-                    {formatDate(job.startDate)} – {formatDate(job.endDate)}
-                  </span>
-                </div>
-                <p className={styles.org}>
-                  {job.name}
-                  {job.location && <span className={styles.orgLocation}>{job.location}</span>}
-                </p>
-                {job.highlights?.length > 0 && (
-                  <ul className={styles.highlights}>
-                    {job.highlights.map((highlight) => (
-                      <li key={highlight}>{highlight}</li>
-                    ))}
-                  </ul>
-                )}
-                {job.keywords?.length > 0 && <Chips items={job.keywords} />}
-              </article>
-            ))}
-          </div>
-        </Section>
+          <aside className={styles.aside}>
+            <Section label="Skills">
+              <div className={styles.skillGroups}>
+                {skillGroups.map((group) => (
+                  <div key={group.name} className={styles.skillGroup}>
+                    <h3 className={styles.skillName}>{group.name}</h3>
+                    <Chips items={group.keywords} />
+                  </div>
+                ))}
+              </div>
+              {skillNotes.length > 0 && (
+                <dl className={styles.notes}>
+                  {skillNotes.map((note) => (
+                    <div key={note.name} className={styles.note}>
+                      <dt className={styles.noteTerm}>{note.name}</dt>
+                      <dd className={styles.noteDesc}>{note.level}</dd>
+                    </div>
+                  ))}
+                </dl>
+              )}
+            </Section>
 
-        <Section label="Education">
-          <div className={styles.entries}>
-            {education.map((school) => (
-              <article key={school.institution} className={styles.entry}>
-                <div className={styles.entryHead}>
-                  <h3 className={styles.role}>{school.institution}</h3>
-                  <span className={styles.dates}>
-                    {formatDate(school.startDate)} – {formatDate(school.endDate)}
-                  </span>
-                </div>
-                <p className={styles.org}>
-                  {school.studyType}
-                  {school.area && <span className={styles.orgLocation}>{school.area}</span>}
-                </p>
-              </article>
-            ))}
-          </div>
-        </Section>
+            <Section label="Education">
+              <div className={styles.entries}>
+                {education.map((school) => (
+                  <Entry
+                    key={school.institution}
+                    title={school.institution}
+                    dates={`${formatDate(school.startDate)} – ${formatDate(school.endDate)}`}
+                    subtitle={school.studyType}
+                    detail={school.area}
+                  />
+                ))}
+              </div>
+            </Section>
 
-        <div className={styles.split}>
-          <Section label="Languages">
-            <dl className={styles.notes}>
-              {languages.map((entry) => (
-                <div key={entry.language} className={styles.note}>
-                  <dt className={styles.noteTerm}>{entry.language}</dt>
-                  <dd className={styles.noteDesc}>{entry.fluency}</dd>
-                </div>
-              ))}
-            </dl>
-          </Section>
+            <Section label="Languages">
+              <dl className={styles.notes}>
+                {languages.map((entry) => (
+                  <div key={entry.language} className={styles.note}>
+                    <dt className={styles.noteTerm}>{entry.language}</dt>
+                    <dd className={styles.noteDesc}>{entry.fluency}</dd>
+                  </div>
+                ))}
+              </dl>
+            </Section>
 
-          <Section label="Conferences">
-            <ul className={styles.conferences}>
-              {conferences.map((conference) => (
-                <li key={`${conference.name}-${conference.year}`}>
-                  <span className={styles.conferenceName}>{conference.name}</span>
-                  <span className={styles.dates}>{conference.year}</span>
-                  <span className={styles.conferencePlace}>{conference.location}</span>
-                </li>
-              ))}
-            </ul>
-          </Section>
+            <Section label="Conferences">
+              <ul className={styles.conferences}>
+                {conferences.map((conference) => (
+                  <li key={`${conference.name}-${conference.year}`}>
+                    <span className={styles.conferenceName}>{conference.name}</span>
+                    <span className={styles.dates}>{conference.year}</span>
+                    <span className={styles.conferencePlace}>{conference.location}</span>
+                  </li>
+                ))}
+              </ul>
+            </Section>
+          </aside>
         </div>
       </div>
     </article>

--- a/src/components/Resume.module.scss
+++ b/src/components/Resume.module.scss
@@ -1,0 +1,337 @@
+// A sheet of paper sitting inside the modal. Warm off-white ground, a fine
+// grain, and a notepad margin rule — enough to read as paper without tipping
+// into stationery pastiche.
+
+$paper: #fdfbf8;
+// The surface the sheet rests on. Warmer and a shade deeper than the paper,
+// so the sheet reads as an object rather than as the whole panel.
+$mat: #f0eae0;
+$ink: #241f1b;
+$ink-soft: #6e655c;
+$ink-faint: #a2988e;
+// The site's own ember, deepened just enough to hold contrast on paper.
+$accent: #d6431f;
+$rule: rgba(36, 31, 27, 0.1);
+
+// Fine paper grain. Generated rather than fetched, like the background.
+$grain: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='g'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='120' height='120' filter='url(%23g)'/%3E%3C/svg%3E");
+
+$serif: 'Iowan Old Style', 'Palatino Linotype', Palatino, Georgia, serif;
+$sans: 'Lato', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+
+.paper {
+  position: absolute;
+  inset: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  background-color: $mat;
+  color: $ink;
+  font-family: $sans;
+  text-align: left;
+  -webkit-font-smoothing: antialiased;
+  padding: 1.75rem;
+
+  &:focus-visible {
+    outline: 2px solid $accent;
+    outline-offset: -3px;
+  }
+}
+
+.sheet {
+  position: relative;
+  max-width: 46rem;
+  min-height: 100%;
+  margin: 0 auto;
+  padding: 3.5rem 2.5rem 4rem 3.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2.75rem;
+  background-color: $paper;
+  // Lifted just enough to catch an edge; paper doesn't hover.
+  box-shadow:
+    0 1px 1px rgba(60, 45, 30, 0.06),
+    0 6px 20px rgba(60, 45, 30, 0.07);
+
+  // Fine grain, clipped to the sheet so the surface stays flat.
+  &::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background-image: $grain;
+    opacity: 0.04;
+    pointer-events: none;
+  }
+
+  // The margin rule, sitting where a notepad's would.
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 1.75rem;
+    width: 1px;
+    background: rgba(214, 67, 31, 0.16);
+  }
+}
+
+// --- header ---
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.name {
+  margin: 0;
+  font-family: $serif;
+  font-size: 2.4rem;
+  font-weight: 600;
+  line-height: 1.05;
+  letter-spacing: -0.015em;
+  text-wrap: balance;
+}
+
+.label {
+  margin: 0;
+  font-size: 1rem;
+  color: $accent;
+  letter-spacing: 0.01em;
+}
+
+.meta {
+  margin: 0;
+  font-size: 0.85rem;
+  color: $ink-faint;
+}
+
+// --- sections ---
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.eyebrow {
+  margin: 0;
+  font-size: 0.68rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: $ink-faint;
+  padding-bottom: 0.6rem;
+  border-bottom: 1px solid $rule;
+}
+
+.summary {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.7;
+  color: $ink-soft;
+  max-width: 62ch;
+}
+
+// --- skills ---
+
+.skillGroups {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.skillGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.skillName {
+  margin: 0;
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: $ink-soft;
+}
+
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.chip {
+  font-size: 0.72rem;
+  line-height: 1;
+  padding: 0.38rem 0.6rem;
+  border: 1px solid $rule;
+  border-radius: 999px;
+  color: $ink-soft;
+  background: rgba(255, 255, 255, 0.6);
+  white-space: nowrap;
+}
+
+// --- definition-style notes, shared by skills and languages ---
+
+.notes {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.note {
+  display: flex;
+  gap: 0.5rem;
+  align-items: baseline;
+  font-size: 0.85rem;
+  line-height: 1.55;
+}
+
+.noteTerm {
+  font-weight: 700;
+  color: $ink;
+  flex: none;
+
+  &::after {
+    content: ' —';
+    color: $ink-faint;
+    font-weight: 400;
+  }
+}
+
+.noteDesc {
+  margin: 0;
+  color: $ink-soft;
+}
+
+// --- experience & education entries ---
+
+.entries {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.entry {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.entryHead {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+}
+
+.role {
+  margin: 0;
+  font-size: 1.02rem;
+  font-weight: 700;
+  line-height: 1.3;
+  text-wrap: balance;
+}
+
+.dates {
+  flex: none;
+  font-size: 0.78rem;
+  color: $ink-faint;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.org {
+  margin: 0;
+  font-size: 0.85rem;
+  color: $accent;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: baseline;
+}
+
+.orgLocation {
+  color: $ink-faint;
+
+  &::before {
+    content: '· ';
+  }
+}
+
+.highlights {
+  margin: 0.15rem 0 0;
+  padding-left: 1.05rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-size: 0.88rem;
+  line-height: 1.6;
+  color: $ink-soft;
+
+  li::marker {
+    color: rgba(214, 67, 31, 0.5);
+  }
+}
+
+// --- conferences ---
+
+.conferences {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+
+  li {
+    display: flex;
+    gap: 0.5rem;
+    align-items: baseline;
+  }
+}
+
+.conferenceName {
+  font-weight: 700;
+}
+
+.conferencePlace {
+  color: $ink-soft;
+}
+
+// --- responsive ---
+
+.split {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+  gap: 2.75rem;
+}
+
+@media (max-width: 40rem) {
+  .paper {
+    padding: 0;
+  }
+
+  .sheet {
+    padding: 2.5rem 1.5rem 3rem 2rem;
+    gap: 2rem;
+    box-shadow: none;
+  }
+
+  .sheet::before {
+    left: 0.9rem;
+  }
+
+  .name {
+    font-size: 1.9rem;
+  }
+
+  .entryHead {
+    flex-direction: column;
+    gap: 0.15rem;
+  }
+}

--- a/src/components/Resume.module.scss
+++ b/src/components/Resume.module.scss
@@ -1,11 +1,9 @@
-// A sheet of paper sitting inside the modal. Warm off-white ground, a fine
-// grain, and a notepad margin rule — enough to read as paper without tipping
-// into stationery pastiche.
+// The modal itself is the sheet of paper: one surface, edge to edge, with a
+// notepad margin rule and a fine grain. The layout answers to the panel's own
+// width rather than the viewport, so it reflows correctly regardless of how
+// large the modal happens to be.
 
 $paper: #fdfbf8;
-// The surface the sheet rests on. Warmer and a shade deeper than the paper,
-// so the sheet reads as an object rather than as the whole panel.
-$mat: #f0eae0;
 $ink: #241f1b;
 $ink-soft: #6e655c;
 $ink-faint: #a2988e;
@@ -24,12 +22,13 @@ $sans: 'Lato', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans
   inset: 0;
   overflow-y: auto;
   overscroll-behavior: contain;
-  background-color: $mat;
+  background-color: $paper;
   color: $ink;
   font-family: $sans;
   text-align: left;
   -webkit-font-smoothing: antialiased;
-  padding: 1.75rem;
+  // Everything below sizes against the panel, not the window.
+  container-type: inline-size;
 
   &:focus-visible {
     outline: 2px solid $accent;
@@ -37,22 +36,33 @@ $sans: 'Lato', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans
   }
 }
 
+// Full-height wrapper so the margin rule and grain span the whole document
+// rather than just the visible scroll window.
 .sheet {
+  --pad-left: clamp(2.4rem, 5cqi, 4rem);
+  --rule-x: calc(var(--pad-left) - 1.3rem);
+
   position: relative;
-  max-width: 46rem;
   min-height: 100%;
-  margin: 0 auto;
-  padding: 3.5rem 2.5rem 4rem 3.25rem;
+  padding:
+    clamp(1.75rem, 4cqi, 3.25rem)
+    clamp(1.5rem, 4cqi, 3rem)
+    clamp(2.5rem, 6cqi, 4rem)
+    var(--pad-left);
   display: flex;
   flex-direction: column;
-  gap: 2.75rem;
-  background-color: $paper;
-  // Lifted just enough to catch an edge; paper doesn't hover.
-  box-shadow:
-    0 1px 1px rgba(60, 45, 30, 0.06),
-    0 6px 20px rgba(60, 45, 30, 0.07);
+  gap: clamp(1.75rem, 3cqi, 2.5rem);
 
-  // Fine grain, clipped to the sheet so the surface stays flat.
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: var(--rule-x);
+    width: 1px;
+    background: rgba(214, 67, 31, 0.16);
+  }
+
   &::after {
     content: '';
     position: absolute;
@@ -61,17 +71,30 @@ $sans: 'Lato', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans
     opacity: 0.04;
     pointer-events: none;
   }
+}
 
-  // The margin rule, sitting where a notepad's would.
-  &::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 1.75rem;
-    width: 1px;
-    background: rgba(214, 67, 31, 0.16);
-  }
+// --- columns ---
+
+.columns {
+  display: grid;
+  grid-template-columns: minmax(0, 1.55fr) minmax(0, 1fr);
+  gap: clamp(1.75rem, 4cqi, 3.25rem);
+  align-items: start;
+}
+
+.main,
+.aside {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.main {
+  gap: clamp(1.75rem, 3cqi, 2.5rem);
+}
+
+.aside {
+  gap: clamp(1.5rem, 2.5cqi, 2.25rem);
 }
 
 // --- header ---
@@ -85,7 +108,7 @@ $sans: 'Lato', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans
 .name {
   margin: 0;
   font-family: $serif;
-  font-size: 2.4rem;
+  font-size: clamp(1.9rem, 4.5cqi, 2.6rem);
   font-weight: 600;
   line-height: 1.05;
   letter-spacing: -0.015em;
@@ -129,7 +152,8 @@ $sans: 'Lato', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans
   font-size: 0.95rem;
   line-height: 1.7;
   color: $ink-soft;
-  max-width: 62ch;
+  // Keeps the lead paragraph at a readable measure in a wide panel.
+  max-width: 64ch;
 }
 
 // --- skills ---
@@ -169,23 +193,25 @@ $sans: 'Lato', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans
   border: 1px solid $rule;
   border-radius: 999px;
   color: $ink-soft;
-  background: rgba(255, 255, 255, 0.6);
+  background: rgba(255, 255, 255, 0.55);
   white-space: nowrap;
 }
 
 // --- definition-style notes, shared by skills and languages ---
 
 .notes {
-  margin: 0;
+  margin: 0.25rem 0 0;
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
 }
 
+// Stacked rather than inline: in a narrow column an inline term/description
+// pair wraps and strands its separator.
 .note {
   display: flex;
-  gap: 0.5rem;
-  align-items: baseline;
+  flex-direction: column;
+  gap: 0.1rem;
   font-size: 0.85rem;
   line-height: 1.55;
 }
@@ -193,21 +219,15 @@ $sans: 'Lato', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans
 .noteTerm {
   font-weight: 700;
   color: $ink;
-  flex: none;
-
-  &::after {
-    content: ' —';
-    color: $ink-faint;
-    font-weight: 400;
-  }
 }
 
 .noteDesc {
   margin: 0;
   color: $ink-soft;
+  min-width: 0;
 }
 
-// --- experience & education entries ---
+// --- entries ---
 
 .entries {
   display: flex;
@@ -254,7 +274,7 @@ $sans: 'Lato', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans
   align-items: baseline;
 }
 
-.orgLocation {
+.orgDetail {
   color: $ink-faint;
 
   &::before {
@@ -290,7 +310,8 @@ $sans: 'Lato', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans
 
   li {
     display: flex;
-    gap: 0.5rem;
+    flex-wrap: wrap;
+    gap: 0.4rem;
     align-items: baseline;
   }
 }
@@ -303,35 +324,22 @@ $sans: 'Lato', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans
   color: $ink-soft;
 }
 
-// --- responsive ---
+// --- reflow ---
 
-.split {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
-  gap: 2.75rem;
+// Below this the two columns no longer have room to sit side by side.
+@container (max-width: 46rem) {
+  .columns {
+    grid-template-columns: minmax(0, 1fr);
+  }
 }
 
-@media (max-width: 40rem) {
-  .paper {
-    padding: 0;
-  }
-
-  .sheet {
-    padding: 2.5rem 1.5rem 3rem 2rem;
-    gap: 2rem;
-    box-shadow: none;
-  }
-
-  .sheet::before {
-    left: 0.9rem;
-  }
-
-  .name {
-    font-size: 1.9rem;
-  }
-
+@container (max-width: 26rem) {
   .entryHead {
     flex-direction: column;
     gap: 0.15rem;
+  }
+
+  .summary {
+    font-size: 0.9rem;
   }
 }

--- a/src/data/resume.json
+++ b/src/data/resume.json
@@ -1,0 +1,174 @@
+{
+  "$schema": "https://raw.githubusercontent.com/jsonresume/resume-schema/v1.0.0/schema.json",
+  "basics": {
+    "name": "Lucas Rasmussen",
+    "label": "Front-End Developer",
+    "summary": "A front-end developer, Lucas Rasmussen has gained much social experience in his time at the Kingston Taphouse. Graduate of the BCIT Technical Web Design Program with experience at all levels of the website development process, from graphic design to CMS. After making the decision to leave Advisor Websites, he joined the Marketing team at Moz as a Web Developer where he exceeded expectations in his role. Lucas was then moved to the Application Development team where he levelled up quickly to a software stack he’d previously been unfamiliar with. He became an important producing and source of knowledge to the rest of the team.",
+    "location": {
+      "city": "Vancouver",
+      "region": "BC",
+      "countryCode": "CA"
+    },
+    "profiles": []
+  },
+  "work": [
+    {
+      "name": "Moz",
+      "position": "Web Developer & Software Engineer II",
+      "location": "Vancouver, BC",
+      "startDate": "2020-11",
+      "endDate": "2024-12",
+      "highlights": [
+        "Identified and resolved cross-team technical issues spanning multiple teams and platforms.",
+        "Created the current navigation on moz.com, including allowing it to be completely Moz staff editable, while retaining visitor user login-state awareness.",
+        "Configured Cloudflare routing via Cloudflare Workers (workers were already in place) to implement new features, including image caching, redirect caching and enabling advanced features such as HTTP/3 throughout the website.",
+        "Rewrote user engagement features based on new designs and marketing goals, such as the SEO Expert quiz and the /top500 page to increase lead capturing.",
+        "Rewrote the checkout and login pages for the company product using a new NextJS application stack with Typescript and ReactJS, integrating with an ExpressJS backend and Stripe billing."
+      ],
+      "keywords": []
+    },
+    {
+      "name": "Advisor Websites",
+      "position": "Senior Full Stack Developer — Team Lead",
+      "location": "Vancouver, BC",
+      "startDate": "2015-02",
+      "endDate": "2020-11",
+      "highlights": [
+        "Used Javascript to create advanced functionality within Wordpress and Drupal websites.",
+        "Leveraged CSS preprocessors (LESS and SASS) to create atomic design standards.",
+        "Stood on the shoulders of front-end frameworks such as Bootstrap and Foundation to save time and build dynamic style guides to be followed by my team.",
+        "Utilized Gulp for rapid SASS compilation as well as templating using gulp-twig.",
+        "Made use of GIT for version control and expanded on our team’s workflow by introducing them to Sourcetree.",
+        "Used the Plugin and Block system within Drupal 8 to add innovative new functionality to a Drupal 8 based platform.",
+        "Created a new Drupal theming system using Pattern Lab as a base.",
+        "Implemented githook-based code sniffing workflows (using CodeClimate) in order to ensure better coding standards for every developer.",
+        "Reviewed most back-end and front-end code related to the company’s product.",
+        "Implemented a continuous integration workflow using Shippable in order to ensure pushed code has minimum bugs before pushing to production.",
+        "Managed a distributed team of up to 5 developers."
+      ],
+      "keywords": [
+        "Drupal 8",
+        "ESLint",
+        "Javascript",
+        "GIT",
+        "Gulp",
+        "JIRA",
+        "Pattern Lab",
+        "PHP",
+        "SASS",
+        "Twig",
+        "Typescript",
+        "ReactJS",
+        "NodeJS",
+        "ExpressJS"
+      ]
+    },
+    {
+      "name": "Advisor Websites",
+      "position": "Project Manager",
+      "location": "Vancouver, BC",
+      "startDate": "2014-01",
+      "endDate": "2015-02",
+      "highlights": [
+        "Managed the communications between the clients and the web designers.",
+        "Assisted the clients in achieving their website goals.",
+        "Troubleshooting complex problems for individuals’ websites."
+      ],
+      "keywords": ["CSS", "Drupal 6", "Javascript", "LESS", "Trello"]
+    },
+    {
+      "name": "Kingston Taphouse",
+      "position": "Website Manager",
+      "location": "Vancouver, BC",
+      "startDate": "2014-01",
+      "endDate": "2015-02",
+      "highlights": [
+        "Updated and maintained already live Wordpress website.",
+        "Created original graphics for hero as well as other locations on website."
+      ],
+      "keywords": ["CSS", "Wordpress", "Adobe Illustrator"]
+    },
+    {
+      "name": "Simply Computing",
+      "position": "Junior Buyer",
+      "location": "Vancouver, BC",
+      "startDate": "2011-12",
+      "endDate": "2012-07",
+      "highlights": [
+        "Promoted two times, from Customer Sales Representative, to Inventory Clerk and finally to Junior Buyer. Started at Simply July 2011.",
+        "Maintained inventory using complex CISPRO Point of Service System.",
+        "Showed ability to learn and create new methods of managing inventory efficiently using the system."
+      ],
+      "keywords": []
+    },
+    {
+      "name": "Kingston Taphouse",
+      "position": "Server Assistant",
+      "location": "Vancouver, BC",
+      "startDate": "2009-07",
+      "endDate": "2014-01",
+      "highlights": [
+        "Worked efficiently and calmly in a stressful high throughput environment.",
+        "Responded to my coworkers needing my help.",
+        "Counted back-bar stock and restocked every night."
+      ],
+      "keywords": []
+    }
+  ],
+  "education": [
+    {
+      "institution": "BCIT",
+      "location": "Vancouver, BC",
+      "area": "Technical Web Design",
+      "studyType": "Certificate of Completion with Distinction",
+      "startDate": "2013-07",
+      "endDate": "2013-12"
+    },
+    {
+      "institution": "Langara College",
+      "location": "Vancouver, BC",
+      "area": "Arts",
+      "studyType": "Associate Degree",
+      "startDate": "2009-09",
+      "endDate": "2012-06"
+    }
+  ],
+  "skills": [
+    {
+      "name": "Languages & Markup",
+      "keywords": ["HTML", "CSS", "SASS", "Javascript", "Typescript", "PHP"]
+    },
+    {
+      "name": "Frameworks & Platforms",
+      "keywords": ["ReactJS", "NodeJS", "Drupal 8", "Foundation", "Twig", "Composer"]
+    },
+    {
+      "name": "Javascript",
+      "level": "Strong browser skills, intermediate in server-side implementations."
+    },
+    {
+      "name": "PHP",
+      "level": "OOP >= 7.0 only. Strong skills from in-work experience."
+    }
+  ],
+  "languages": [
+    {
+      "language": "English",
+      "fluency": "Native speaking"
+    },
+    {
+      "language": "French",
+      "fluency": "BC Dogwood certificate. Casual understanding in practise."
+    }
+  ],
+  "meta": {
+    "version": "v1.0.0",
+    "conferences": [
+      { "name": "DrupalCon", "year": "2017", "location": "Baltimore" },
+      { "name": "DrupalCon", "year": "2018", "location": "Nashville" },
+      { "name": "Drupal Pacific Summit", "year": "2017", "location": "Vancouver" },
+      { "name": "Confoo", "year": "2017", "location": "Vancouver" },
+      { "name": "Confoo", "year": "2018", "location": "Vancouver" }
+    ]
+  }
+}


### PR DESCRIPTION
Follow-up to #6, which is merged. This branch was rebased onto current
`master` so it carries only the three commits that were never part of that
merge.

The modal loaded `registry.jsonresume.org` in an iframe, so the panel was at
the mercy of a third-party host that was not answering. The content is small
and static, so it ships with the site now.

## Data

`src/data/resume.json` holds the content, transcribed from a supplied PDF, and
**validates against the official `resume-schema` v1.0.1** (checked with ajv, not
just asserted).

Two shaping decisions came out of that check:

- The schema sets `additionalProperties: false` at the **root**, so a top-level
  `conferences` key would have made the file invalid. Conferences live under
  `meta` instead, which is the spec's sanctioned extension point
  (`additionalProperties: true`).
- Per-role technologies use `keywords` on work entries, which the schema does
  allow (`work.items.additionalProperties: true`).

The flat twelve-item skills list is grouped into *Languages & Markup* and
*Frameworks & Platforms*. The JavaScript and PHP proficiency lines moved from the
PDF's Languages section into `skills` as `level` notes, since JSON Resume's
`languages` is for spoken languages. Every role is preserved, including the
earlier non-development ones.

## Layout

The panel is the sheet of paper itself — one surface, edge to edge, with a
notepad margin rule and a generated grain (an inline SVG turbulence filter
rather than a fetched texture, matching how the background is drawn). The accent
is the site's own ember orange rather than a generic paper-stock terracotta, so
the sheet belongs to the same world as the landscape behind it. Type is a system
serif for the name against Lato for the body, adding no font requests.

Filling the panel means the text has to stay readable at whatever width the
modal happens to be, so the layout goes two-column when there is room and
collapses to one when there is not. That reflow keys off **container queries**
rather than the viewport, because the modal is sized independently of the window
and it is the panel's width that decides whether two columns fit.

## Modal proportions

Sizing the modal at `80vw` by `80vh` gave it no shape of its own — it inherited
the display's, which meant a 16:9 letterbox on a monitor and a 0.46:1 sliver on
a phone, worsening as displays got wider. It is now sized as a document, capped
on both axes, with a third term capping width against height so a short
landscape window does not letterbox either.

Measured across twelve viewports, the aspect ratio moved from a 0.46–2.40 spread
to 0.47–1.70:

| Viewport | Before | After |
| -------- | ------ | ----- |
| iPad portrait | 0.75 | 0.73 |
| Laptop 1440 | 1.60 | 1.48 |
| Desktop 1920 | 1.78 | 1.48 |
| Ultrawide 2560 | **2.37** | **1.48** |
| Short landscape 1440x600 | **2.40** | **1.70** |

Also switches the modal from `min-width`/`min-height` to `width`/`height`, so the
expand animates the properties it actually changes.

## Verification

Clean `npm ci` → `npm run lint` → `npm run build`, 0 vulnerabilities. Driven in a
real browser: no console or page errors, no horizontal overflow at 390 / 834 /
1440px, the panel is keyboard focusable and scrollable, and the expand still
animates and fires `transitionend` to reveal the sheet.

## Open questions

Two content points worth a maintainer decision, both deliberately left alone:

- The summary keeps the PDF's wording verbatim, including *"He became an
  important producing and source of knowledge to the rest of the team"*, which
  reads like it is missing a word. Changing it would have meant guessing.
- No email or phone appears in `basics`, because the PDF carried none and
  publishing an address is not a call to make unprompted.

Separately, there is still no way to dismiss the panel once it opens — true of
the original Vue app too, so not a regression, but easy to add.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NMtuu5EBhZVwHHdYMFa9dm

---
_Generated by [Claude Code](https://claude.ai/code/session_01NMtuu5EBhZVwHHdYMFa9dm)_