### PR TITLE
Fix a dropped word in the resume summary

### DIFF
--- a/src/data/resume.json
+++ b/src/data/resume.json
@@ -3,7 +3,7 @@
   "basics": {
     "name": "Lucas Rasmussen",
     "label": "Front-End Developer",
-    "summary": "A front-end developer, Lucas Rasmussen has gained much social experience in his time at the Kingston Taphouse. Graduate of the BCIT Technical Web Design Program with experience at all levels of the website development process, from graphic design to CMS. After making the decision to leave Advisor Websites, he joined the Marketing team at Moz as a Web Developer where he exceeded expectations in his role. Lucas was then moved to the Application Development team where he levelled up quickly to a software stack he’d previously been unfamiliar with. He became an important producing and source of knowledge to the rest of the team.",
+    "summary": "A front-end developer, Lucas Rasmussen has gained much social experience in his time at the Kingston Taphouse. Graduate of the BCIT Technical Web Design Program with experience at all levels of the website development process, from graphic design to CMS. After making the decision to leave Advisor Websites, he joined the Marketing team at Moz as a Web Developer where he exceeded expectations in his role. Lucas was then moved to the Application Development team where he levelled up quickly to a software stack he’d previously been unfamiliar with. He became an important producer and source of knowledge to the rest of the team.",
     "location": {
       "city": "Vancouver",
       "region": "BC",


### PR DESCRIPTION
The summary's closing sentence read:

> He became an important **producing** and source of knowledge to the rest of
> the team.

That was transcribed verbatim from the source PDF, where a word appears to have
gone missing. Changing `producing` to `producer` is the smallest edit that makes
it read, and leaves the rest of the sentence exactly as written:

> He became an important **producer** and source of knowledge to the rest of the
> team.

One word in `src/data/resume.json`. No contact information was added — `basics`
still carries only `name`, `label`, `summary`, `location` and an empty
`profiles`.

`resume.json` still validates against the official `resume-schema` v1.0.1, and
`npm run lint` and `npm run build` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NMtuu5EBhZVwHHdYMFa9dm

---
_Generated by [Claude Code](https://claude.ai/code/session_01NMtuu5EBhZVwHHdYMFa9dm)_