### PR TITLE
Add four more background themes and a space-mode toggle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,7 @@
         "@fortawesome/react-fontawesome": "^3.5.0",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
-        "react-router": "^8.3.0",
-        "react-tooltip": "^6.0.8"
+        "react-router": "^8.3.0"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -1008,31 +1007,6 @@
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
-    },
-    "node_modules/@floating-ui/core": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
-      "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/utils": "^0.2.12"
-      }
-    },
-    "node_modules/@floating-ui/dom": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
-      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/core": "^1.7.5",
-        "@floating-ui/utils": "^0.2.11"
-      }
-    },
-    "node_modules/@floating-ui/utils": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
-      "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
-      "license": "MIT"
     },
     "node_modules/@fortawesome/fontawesome-common-types": {
       "version": "7.3.1",
@@ -2576,15 +2550,6 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/clsx": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -3829,20 +3794,6 @@
         "react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-tooltip": {
-      "version": "6.0.8",
-      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-6.0.8.tgz",
-      "integrity": "sha512-VPjtBPyoFwq72QVE6GYB/LtfEg/mnFBHqL0nD0oNNmjH8EZYFyBwgnFKNCOp5zCte45k1weXjKc0wXE6NICpfg==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/dom": "1.7.6",
-        "clsx": "2.1.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.14.0",
-        "react-dom": ">=16.14.0"
       }
     },
     "node_modules/readdirp": {

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
     "@fortawesome/react-fontawesome": "^3.5.0",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
-    "react-router": "^8.3.0",
-    "react-tooltip": "^6.0.8"
+    "react-router": "^8.3.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -123,7 +123,7 @@ export default function App() {
               sourceNodeRef={resumeRef}
               onComplete={handleBurnComplete}
               onReady={handleBurnReady}
-              durationMs={1100}
+              durationMs={1600}
             />
           )}
         </div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,7 +8,8 @@ import Grid from './components/Grid.jsx';
 import Resume from './components/Resume.jsx';
 import BurnTransition from './components/BurnTransition.jsx';
 import { TOOLTIP_ID } from './constants.js';
-import { useBackgroundTheme } from './backgrounds.js';
+import { BACKGROUND_THEMES, useBackgroundTheme } from './backgrounds.js';
+import { useSpaceMode } from './spaceMode.js';
 import styles from './App.module.scss';
 import 'react-tooltip/dist/react-tooltip.css';
 
@@ -17,7 +18,8 @@ export default function App() {
   // happen together — a single `open` state replaces the old
   // expanded/showResume pair entirely.
   const [open, setOpen] = useState(false);
-  const { theme, cycleTheme } = useBackgroundTheme();
+  const { theme, themeId, selectTheme } = useBackgroundTheme();
+  const { spaceMode, toggleSpaceMode } = useSpaceMode();
   const [burning, setBurning] = useState(false);
   // Separate from `burning`: setup (compile/capture/texture-upload) can take
   // a while, especially on slower devices. Only flip the resume/modal hidden
@@ -90,7 +92,7 @@ export default function App() {
 
   return (
     <div className={styles.app} onClick={handleBackdropClick}>
-      <theme.Component />
+      <theme.Component spaceMode={spaceMode} />
       {open && (
         <div
           ref={modalRef}
@@ -134,8 +136,11 @@ export default function App() {
         buttonRef={startButtonRef}
         expanded={open}
         onToggle={toggleResume}
-        backgroundThemeLabel={theme.label}
-        onCycleBackground={cycleTheme}
+        themes={BACKGROUND_THEMES}
+        activeThemeId={themeId}
+        onSelectTheme={selectTheme}
+        spaceMode={spaceMode}
+        onToggleSpaceMode={toggleSpaceMode}
       />
       <Tooltip id={TOOLTIP_ID} className="app-tooltip" classNameArrow="app-tooltip-arrow" />
     </div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,17 +1,14 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Route, Routes } from 'react-router';
-import { Tooltip } from 'react-tooltip';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faXmark } from '@fortawesome/free-solid-svg-icons';
 import StartMenu from './components/StartMenu.jsx';
 import Grid from './components/Grid.jsx';
 import Resume from './components/Resume.jsx';
 import BurnTransition from './components/BurnTransition.jsx';
-import { TOOLTIP_ID } from './constants.js';
 import { BACKGROUND_THEMES, useBackgroundTheme } from './backgrounds.js';
 import { useSpaceMode } from './spaceMode.js';
 import styles from './App.module.scss';
-import 'react-tooltip/dist/react-tooltip.css';
 
 export default function App() {
   // There's no more grow/shrink morph, so opening and showing the resume
@@ -142,7 +139,6 @@ export default function App() {
         spaceMode={spaceMode}
         onToggleSpaceMode={toggleSpaceMode}
       />
-      <Tooltip id={TOOLTIP_ID} className="app-tooltip" classNameArrow="app-tooltip-arrow" />
     </div>
   );
 }

--- a/src/backgrounds.js
+++ b/src/backgrounds.js
@@ -1,10 +1,20 @@
 import { useCallback, useState } from 'react';
 import LandscapeBg from './components/LandscapeBg.jsx';
+import DesertBg from './components/DesertBg.jsx';
+import TundraBg from './components/TundraBg.jsx';
+import RainforestBg from './components/RainforestBg.jsx';
+import OceanBg from './components/OceanBg.jsx';
 
 // The wallpaper is a swappable "theme" rather than a single hardcoded
 // component, so adding another procedural scene later is just another entry
-// here — nothing in App.jsx or the taskbar action needs to change.
-export const BACKGROUND_THEMES = [{ id: 'sunset', label: 'Sunset Ridge', Component: LandscapeBg }];
+// here — nothing in App.jsx or the taskbar menu needs to change.
+export const BACKGROUND_THEMES = [
+  { id: 'sunset', label: 'Sunset Ridge', Component: LandscapeBg },
+  { id: 'desert', label: 'Dune Sea', Component: DesertBg },
+  { id: 'tundra', label: 'Polar Aurora', Component: TundraBg },
+  { id: 'rainforest', label: 'Rainforest Canopy', Component: RainforestBg },
+  { id: 'ocean', label: 'Open Ocean', Component: OceanBg },
+];
 
 const STORAGE_KEY = 'lr-background-theme';
 
@@ -23,21 +33,22 @@ function readStoredThemeId() {
 export function useBackgroundTheme() {
   const [themeId, setThemeId] = useState(readStoredThemeId);
 
-  const cycleTheme = useCallback(() => {
-    setThemeId((current) => {
-      const index = BACKGROUND_THEMES.findIndex((theme) => theme.id === current);
-      const next = BACKGROUND_THEMES[(index + 1) % BACKGROUND_THEMES.length];
-      try {
-        window.localStorage.setItem(STORAGE_KEY, next.id);
-      } catch {
-        // Best-effort; a disabled/full localStorage just means the choice
-        // doesn't survive a reload.
-      }
-      return next.id;
-    });
+  // Direct-pick rather than cycling, now that the taskbar UI is a dropdown
+  // listing every theme by name. Ignores unknown ids defensively — the menu
+  // itself only ever passes ids from BACKGROUND_THEMES, so this only matters
+  // if that ever changes.
+  const selectTheme = useCallback((id) => {
+    if (!BACKGROUND_THEMES.some((theme) => theme.id === id)) return;
+    setThemeId(id);
+    try {
+      window.localStorage.setItem(STORAGE_KEY, id);
+    } catch {
+      // Best-effort; a disabled/full localStorage just means the choice
+      // doesn't survive a reload.
+    }
   }, []);
 
   const theme =
     BACKGROUND_THEMES.find((candidate) => candidate.id === themeId) ?? BACKGROUND_THEMES[0];
-  return { theme, cycleTheme };
+  return { theme, themeId, selectTheme };
 }

--- a/src/components/BackgroundMenu.jsx
+++ b/src/components/BackgroundMenu.jsx
@@ -60,9 +60,16 @@ export default function BackgroundMenu({ themes, activeId, onSelect }) {
   }, [open, themes, activeId]);
 
   // Tab-ing focus out of the menu (not just clicking away) should close it
-  // too — relatedTarget is the element focus is moving to.
+  // too — relatedTarget is the element focus is moving to. Only acts when
+  // relatedTarget is an actual element: on iOS Safari, buttons don't
+  // reliably receive focus from a tap, so tapping a different menu item can
+  // blur the previously-focused one with relatedTarget null — treating that
+  // as "focus left the menu" would close it before the tap's own click/
+  // onSelect had a chance to fire, silently eating the selection.
   const handleBlur = (event) => {
-    if (!wrapperRef.current?.contains(event.relatedTarget)) setOpen(false);
+    if (event.relatedTarget && !wrapperRef.current?.contains(event.relatedTarget)) {
+      setOpen(false);
+    }
   };
 
   return (

--- a/src/components/BackgroundMenu.jsx
+++ b/src/components/BackgroundMenu.jsx
@@ -1,0 +1,114 @@
+import { useEffect, useRef, useState } from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faPanorama, faCheck } from '@fortawesome/free-solid-svg-icons';
+import { TOOLTIP_ID } from '../constants.js';
+import styles from './BackgroundMenu.module.scss';
+
+// Mirrors the idioms App.jsx already uses for the résumé modal (Escape to
+// close + refocus the trigger, ref-containment for outside-click/blur to
+// dismiss, moving focus in on open) rather than inventing new ones for what
+// is, structurally, the same "small dismissable overlay" problem.
+export default function BackgroundMenu({ themes, activeId, onSelect }) {
+  const [open, setOpen] = useState(false);
+  const wrapperRef = useRef(null);
+  const triggerRef = useRef(null);
+  const itemRefs = useRef([]);
+
+  const activeTheme = themes.find((theme) => theme.id === activeId) ?? themes[0];
+
+  const close = () => {
+    setOpen(false);
+    triggerRef.current?.focus();
+  };
+
+  useEffect(() => {
+    if (!open) return undefined;
+
+    const activeIndex = themes.findIndex((theme) => theme.id === activeId);
+    itemRefs.current[activeIndex >= 0 ? activeIndex : 0]?.focus();
+
+    const handleKeyDown = (event) => {
+      const items = itemRefs.current;
+      if (event.key === 'Escape') {
+        event.stopPropagation();
+        close();
+        return;
+      }
+      const currentIndex = items.findIndex((el) => el === document.activeElement);
+      if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        items[(currentIndex + 1) % items.length]?.focus();
+      } else if (event.key === 'ArrowUp') {
+        event.preventDefault();
+        items[(currentIndex - 1 + items.length) % items.length]?.focus();
+      } else if (event.key === 'Home') {
+        event.preventDefault();
+        items[0]?.focus();
+      } else if (event.key === 'End') {
+        event.preventDefault();
+        items[items.length - 1]?.focus();
+      }
+    };
+
+    const handlePointerDown = (event) => {
+      if (!wrapperRef.current?.contains(event.target)) setOpen(false);
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    document.addEventListener('pointerdown', handlePointerDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+      document.removeEventListener('pointerdown', handlePointerDown);
+    };
+  }, [open, themes, activeId]);
+
+  // Tab-ing focus out of the menu (not just clicking away) should close it
+  // too — relatedTarget is the element focus is moving to.
+  const handleBlur = (event) => {
+    if (!wrapperRef.current?.contains(event.relatedTarget)) setOpen(false);
+  };
+
+  return (
+    <div className={styles.wrapper} ref={wrapperRef} onBlur={handleBlur}>
+      <button
+        type="button"
+        ref={triggerRef}
+        className={styles.trigger}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label="Change background"
+        onClick={() => setOpen((current) => !current)}
+        data-tooltip-id={TOOLTIP_ID}
+        data-tooltip-content={`Background: ${activeTheme.label}`}
+        data-tooltip-place="top-start"
+      >
+        <FontAwesomeIcon icon={faPanorama} />
+      </button>
+      {open && (
+        <div role="menu" aria-label="Background themes" className={styles.menu}>
+          {themes.map((theme, index) => (
+            <button
+              key={theme.id}
+              type="button"
+              ref={(el) => {
+                itemRefs.current[index] = el;
+              }}
+              role="menuitemradio"
+              aria-checked={theme.id === activeId}
+              className={styles.item}
+              onClick={() => {
+                onSelect(theme.id);
+                close();
+              }}
+            >
+              <span className={styles.checkSlot}>
+                {theme.id === activeId && <FontAwesomeIcon icon={faCheck} />}
+              </span>
+              {theme.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/BackgroundMenu.jsx
+++ b/src/components/BackgroundMenu.jsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faPanorama, faCheck } from '@fortawesome/free-solid-svg-icons';
-import { TOOLTIP_ID } from '../constants.js';
 import styles from './BackgroundMenu.module.scss';
 
 // Mirrors the idioms App.jsx already uses for the résumé modal (Escape to
@@ -13,8 +12,6 @@ export default function BackgroundMenu({ themes, activeId, onSelect }) {
   const wrapperRef = useRef(null);
   const triggerRef = useRef(null);
   const itemRefs = useRef([]);
-
-  const activeTheme = themes.find((theme) => theme.id === activeId) ?? themes[0];
 
   const close = () => {
     setOpen(false);
@@ -78,9 +75,6 @@ export default function BackgroundMenu({ themes, activeId, onSelect }) {
         aria-expanded={open}
         aria-label="Change background"
         onClick={() => setOpen((current) => !current)}
-        data-tooltip-id={TOOLTIP_ID}
-        data-tooltip-content={`Background: ${activeTheme.label}`}
-        data-tooltip-place="top-start"
       >
         <FontAwesomeIcon icon={faPanorama} />
       </button>

--- a/src/components/BackgroundMenu.module.scss
+++ b/src/components/BackgroundMenu.module.scss
@@ -1,0 +1,76 @@
+@use '../styles/variables' as *;
+
+.wrapper {
+  position: relative;
+}
+
+// Same icon-button look as StartActions.module.scss's `.action` — this
+// trigger sits in the same taskbar row, so it needs to read as one of them.
+.trigger {
+  background: none;
+  border: none;
+  padding: 0 0.25rem;
+  cursor: pointer;
+  color: white;
+  font-size: 1.5rem;
+  line-height: 1;
+}
+
+// Popover above the taskbar, same frosted-glass language as .start itself.
+.menu {
+  position: absolute;
+  bottom: calc(100% + 0.5rem);
+  left: 50%;
+  transform: translateX(-50%);
+  min-width: 12rem;
+  padding: 0.35rem;
+  border-radius: 10px;
+  background-color: rgba(8, 8, 8, 0.82);
+  backdrop-filter: blur(24px) saturate(150%);
+  -webkit-backdrop-filter: blur(24px) saturate(150%);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+@supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+  .menu {
+    background-color: rgba(8, 8, 8, 0.94);
+  }
+}
+
+.item {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.5rem 0.6rem;
+  border: none;
+  border-radius: 6px;
+  background: none;
+  color: white;
+  font-family: inherit;
+  font-size: 0.9rem;
+  text-align: left;
+  cursor: pointer;
+
+  &:hover,
+  &:focus-visible {
+    background-color: rgba(255, 255, 255, 0.12);
+  }
+
+  &:focus-visible {
+    outline: 2px solid $accent;
+    outline-offset: -2px;
+  }
+}
+
+.checkSlot {
+  width: 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: $accent;
+  flex-shrink: 0;
+}

--- a/src/components/BurnTransition.jsx
+++ b/src/components/BurnTransition.jsx
@@ -245,10 +245,10 @@ export default function BurnTransition({ sourceNodeRef, onComplete, onReady, dur
       gl.uniform1i(uTexture, 0);
 
       // Runs well past 1 so both the char/fade zone AND the smoke trail
-      // behind it (which lingers a bit after each patch finishes charring —
-      // see burn.frag) have time to fully clear before the completion
-      // handler tears everything down.
-      const finishAt = 1.7;
+      // behind it (which now lingers noticeably longer after each patch
+      // finishes charring — see burn.frag's slower decay) have time to
+      // fully clear before the completion handler tears everything down.
+      const finishAt = 2.1;
 
       const loop = (now) => {
         if (cancelled) return;

--- a/src/components/DesertBg.jsx
+++ b/src/components/DesertBg.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
 import vertSource from '../shaders/landscape.vert?raw';
 import commonSource from '../shaders/common.glsl?raw';
-import themeFragSource from '../shaders/landscape.frag?raw';
+import themeFragSource from '../shaders/desert.frag?raw';
 import { createSpaceRamp } from '../spaceRamp.js';
 import styles from './LandscapeBg.module.scss';
 
@@ -9,23 +9,8 @@ import styles from './LandscapeBg.module.scss';
 // concatenates ahead of its own scene-specific source before compiling.
 const fragSource = `${commonSource}\n${themeFragSource}`;
 
-// Ridge silhouettes have hard edges, so full retina resolution is visibly
-// sharper than a plain gradient would justify — render at the device's
-// actual pixel density rather than downsampling. Capped at 3 purely as a
-// safety ceiling against pathological values (e.g. browser zoom inflating
-// devicePixelRatio well past what any real display panel uses).
+// See LandscapeBg.jsx's identical constant for the reasoning.
 const MAX_DPR = 3;
-// A stylized day, not a real 24-hour one — fast enough that the sun's drift
-// is noticeable within a normal page visit, slow enough to still read as
-// ambient rather than an obvious animation.
-const SUN_CYCLE_MS = 3 * 60 * 1000;
-
-// Phase of the current cycle elapsed (0..1) — real wall-clock time, not
-// performance.now(), so every visitor's sun sits at the same height at a
-// given moment regardless of when their own session started.
-function sunCyclePhase() {
-  return (Date.now() % SUN_CYCLE_MS) / SUN_CYCLE_MS;
-}
 
 function compile(gl, type, source) {
   const shader = gl.createShader(type);
@@ -46,8 +31,6 @@ function createProgram(gl) {
   gl.attachShader(program, vert);
   gl.attachShader(program, frag);
   gl.linkProgram(program);
-  // Attached shaders stay alive until the program is deleted, so they can be
-  // released as soon as the link succeeds.
   gl.deleteShader(vert);
   gl.deleteShader(frag);
   if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
@@ -58,24 +41,14 @@ function createProgram(gl) {
   return program;
 }
 
-// If anything below fails the canvas is simply never painted. It stays
-// transparent, so the app's gradient shows through untouched — no state and
-// no fallback branch needed.
-export default function LandscapeBg({ spaceMode = false }) {
+// Same lifecycle shape as LandscapeBg.jsx (webgl2/webgl fallback,
+// reduced-motion, visibility pause, context-loss, full teardown) — this is a
+// blazing-midday scene rather than a day/night one, so there's no uSunPhase.
+export default function DesertBg({ spaceMode = false }) {
   const canvasRef = useRef(null);
-  // Read fresh inside the mount effect's rAF loop (which never re-runs while
-  // this component stays mounted) rather than closing over the prop's
-  // initial value — see createSpaceRamp's caller below.
   const spaceModeRef = useRef(spaceMode);
-  // Holds the mount effect's own `draw`, so the effect below can force one
-  // redraw right when spaceMode flips even if no rAF loop is running (e.g.
-  // reduced motion) — otherwise the canvas would just keep showing whatever
-  // it last drew until something else happened to trigger a frame.
   const drawRef = useRef(null);
 
-  // Writing a ref during render is disallowed (react-hooks/refs) — this
-  // effect is the safe place, and runs before the "force a redraw" effect
-  // below since effects commit in declaration order.
   useEffect(() => {
     spaceModeRef.current = spaceMode;
   }, [spaceMode]);
@@ -94,7 +67,6 @@ export default function LandscapeBg({ spaceMode = false }) {
     try {
       program = createProgram(gl);
     } catch {
-      // A driver that can't compile this leaves the gradient in place.
       return undefined;
     }
 
@@ -106,7 +78,6 @@ export default function LandscapeBg({ spaceMode = false }) {
     const uResolution = gl.getUniformLocation(program, 'uResolution');
     const uTime = gl.getUniformLocation(program, 'uTime');
     const uSeed = gl.getUniformLocation(program, 'uSeed');
-    const uSunPhase = gl.getUniformLocation(program, 'uSunPhase');
     const uSpaceT = gl.getUniformLocation(program, 'uSpaceT');
     const spaceT = createSpaceRamp(spaceModeRef.current);
 
@@ -129,14 +100,11 @@ export default function LandscapeBg({ spaceMode = false }) {
     const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
     let frame = 0;
     let start = performance.now();
-    // Frozen time for reduced motion still renders the full scene, just
-    // without the drift.
     let elapsed = 0;
 
     const draw = () => {
       resize();
       gl.uniform1f(uTime, elapsed);
-      gl.uniform1f(uSunPhase, sunCyclePhase());
       gl.uniform1f(uSpaceT, spaceT(spaceModeRef.current));
       gl.drawArrays(gl.TRIANGLES, 0, 3);
     };
@@ -154,13 +122,10 @@ export default function LandscapeBg({ spaceMode = false }) {
 
     const play = () => {
       if (frame || reduceMotion.matches || document.hidden) return;
-      // Rebase so the scene doesn't jump forward by however long we paused.
       start = performance.now() - elapsed * 1000;
       frame = requestAnimationFrame(loop);
     };
 
-    // Burning battery on an ambient background in a tab nobody is looking at
-    // is pure waste.
     const onVisibility = () => (document.hidden ? stop() : play());
     const onMotionChange = () => (reduceMotion.matches ? (stop(), draw()) : play());
     const onResize = () => {
@@ -194,8 +159,6 @@ export default function LandscapeBg({ spaceMode = false }) {
     };
   }, []);
 
-  // Forces a redraw the instant spaceMode changes, in case no rAF loop is
-  // currently running to pick it up on its own (see drawRef's comment above).
   useEffect(() => {
     drawRef.current?.();
   }, [spaceMode]);

--- a/src/components/DesertBg.jsx
+++ b/src/components/DesertBg.jsx
@@ -3,6 +3,7 @@ import vertSource from '../shaders/landscape.vert?raw';
 import commonSource from '../shaders/common.glsl?raw';
 import themeFragSource from '../shaders/desert.frag?raw';
 import { createSpaceRamp } from '../spaceRamp.js';
+import { getSceneSeed } from '../seed.js';
 import styles from './LandscapeBg.module.scss';
 
 // common.glsl isn't a real GLSL module — just a text prefix every theme
@@ -84,7 +85,7 @@ export default function DesertBg({ spaceMode = false }) {
     gl.useProgram(program);
     gl.enableVertexAttribArray(aPosition);
     gl.vertexAttribPointer(aPosition, 2, gl.FLOAT, false, 0, 0);
-    gl.uniform1f(uSeed, Math.random() * 100);
+    gl.uniform1f(uSeed, getSceneSeed());
 
     const resize = () => {
       const dpr = Math.min(window.devicePixelRatio || 1, MAX_DPR);

--- a/src/components/LandscapeBg.jsx
+++ b/src/components/LandscapeBg.jsx
@@ -3,6 +3,7 @@ import vertSource from '../shaders/landscape.vert?raw';
 import commonSource from '../shaders/common.glsl?raw';
 import themeFragSource from '../shaders/landscape.frag?raw';
 import { createSpaceRamp } from '../spaceRamp.js';
+import { getSceneSeed } from '../seed.js';
 import styles from './LandscapeBg.module.scss';
 
 // common.glsl isn't a real GLSL module — just a text prefix every theme
@@ -113,7 +114,7 @@ export default function LandscapeBg({ spaceMode = false }) {
     gl.useProgram(program);
     gl.enableVertexAttribArray(aPosition);
     gl.vertexAttribPointer(aPosition, 2, gl.FLOAT, false, 0, 0);
-    gl.uniform1f(uSeed, Math.random() * 100);
+    gl.uniform1f(uSeed, getSceneSeed());
 
     const resize = () => {
       const dpr = Math.min(window.devicePixelRatio || 1, MAX_DPR);

--- a/src/components/OceanBg.jsx
+++ b/src/components/OceanBg.jsx
@@ -3,6 +3,7 @@ import vertSource from '../shaders/landscape.vert?raw';
 import commonSource from '../shaders/common.glsl?raw';
 import themeFragSource from '../shaders/ocean.frag?raw';
 import { createSpaceRamp } from '../spaceRamp.js';
+import { getSceneSeed } from '../seed.js';
 import styles from './LandscapeBg.module.scss';
 
 // common.glsl isn't a real GLSL module — just a text prefix every theme
@@ -84,7 +85,7 @@ export default function OceanBg({ spaceMode = false }) {
     gl.useProgram(program);
     gl.enableVertexAttribArray(aPosition);
     gl.vertexAttribPointer(aPosition, 2, gl.FLOAT, false, 0, 0);
-    gl.uniform1f(uSeed, Math.random() * 100);
+    gl.uniform1f(uSeed, getSceneSeed());
 
     const resize = () => {
       const dpr = Math.min(window.devicePixelRatio || 1, MAX_DPR);

--- a/src/components/OceanBg.jsx
+++ b/src/components/OceanBg.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
 import vertSource from '../shaders/landscape.vert?raw';
 import commonSource from '../shaders/common.glsl?raw';
-import themeFragSource from '../shaders/landscape.frag?raw';
+import themeFragSource from '../shaders/ocean.frag?raw';
 import { createSpaceRamp } from '../spaceRamp.js';
 import styles from './LandscapeBg.module.scss';
 
@@ -9,23 +9,8 @@ import styles from './LandscapeBg.module.scss';
 // concatenates ahead of its own scene-specific source before compiling.
 const fragSource = `${commonSource}\n${themeFragSource}`;
 
-// Ridge silhouettes have hard edges, so full retina resolution is visibly
-// sharper than a plain gradient would justify — render at the device's
-// actual pixel density rather than downsampling. Capped at 3 purely as a
-// safety ceiling against pathological values (e.g. browser zoom inflating
-// devicePixelRatio well past what any real display panel uses).
+// See LandscapeBg.jsx's identical constant for the reasoning.
 const MAX_DPR = 3;
-// A stylized day, not a real 24-hour one — fast enough that the sun's drift
-// is noticeable within a normal page visit, slow enough to still read as
-// ambient rather than an obvious animation.
-const SUN_CYCLE_MS = 3 * 60 * 1000;
-
-// Phase of the current cycle elapsed (0..1) — real wall-clock time, not
-// performance.now(), so every visitor's sun sits at the same height at a
-// given moment regardless of when their own session started.
-function sunCyclePhase() {
-  return (Date.now() % SUN_CYCLE_MS) / SUN_CYCLE_MS;
-}
 
 function compile(gl, type, source) {
   const shader = gl.createShader(type);
@@ -46,8 +31,6 @@ function createProgram(gl) {
   gl.attachShader(program, vert);
   gl.attachShader(program, frag);
   gl.linkProgram(program);
-  // Attached shaders stay alive until the program is deleted, so they can be
-  // released as soon as the link succeeds.
   gl.deleteShader(vert);
   gl.deleteShader(frag);
   if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
@@ -58,24 +41,14 @@ function createProgram(gl) {
   return program;
 }
 
-// If anything below fails the canvas is simply never painted. It stays
-// transparent, so the app's gradient shows through untouched — no state and
-// no fallback branch needed.
-export default function LandscapeBg({ spaceMode = false }) {
+// Same lifecycle shape as LandscapeBg.jsx (webgl2/webgl fallback,
+// reduced-motion, visibility pause, context-loss, full teardown) — the sun
+// here sits at a fixed height (no day/night cycle), so there's no uSunPhase.
+export default function OceanBg({ spaceMode = false }) {
   const canvasRef = useRef(null);
-  // Read fresh inside the mount effect's rAF loop (which never re-runs while
-  // this component stays mounted) rather than closing over the prop's
-  // initial value — see createSpaceRamp's caller below.
   const spaceModeRef = useRef(spaceMode);
-  // Holds the mount effect's own `draw`, so the effect below can force one
-  // redraw right when spaceMode flips even if no rAF loop is running (e.g.
-  // reduced motion) — otherwise the canvas would just keep showing whatever
-  // it last drew until something else happened to trigger a frame.
   const drawRef = useRef(null);
 
-  // Writing a ref during render is disallowed (react-hooks/refs) — this
-  // effect is the safe place, and runs before the "force a redraw" effect
-  // below since effects commit in declaration order.
   useEffect(() => {
     spaceModeRef.current = spaceMode;
   }, [spaceMode]);
@@ -94,7 +67,6 @@ export default function LandscapeBg({ spaceMode = false }) {
     try {
       program = createProgram(gl);
     } catch {
-      // A driver that can't compile this leaves the gradient in place.
       return undefined;
     }
 
@@ -106,7 +78,6 @@ export default function LandscapeBg({ spaceMode = false }) {
     const uResolution = gl.getUniformLocation(program, 'uResolution');
     const uTime = gl.getUniformLocation(program, 'uTime');
     const uSeed = gl.getUniformLocation(program, 'uSeed');
-    const uSunPhase = gl.getUniformLocation(program, 'uSunPhase');
     const uSpaceT = gl.getUniformLocation(program, 'uSpaceT');
     const spaceT = createSpaceRamp(spaceModeRef.current);
 
@@ -129,14 +100,11 @@ export default function LandscapeBg({ spaceMode = false }) {
     const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
     let frame = 0;
     let start = performance.now();
-    // Frozen time for reduced motion still renders the full scene, just
-    // without the drift.
     let elapsed = 0;
 
     const draw = () => {
       resize();
       gl.uniform1f(uTime, elapsed);
-      gl.uniform1f(uSunPhase, sunCyclePhase());
       gl.uniform1f(uSpaceT, spaceT(spaceModeRef.current));
       gl.drawArrays(gl.TRIANGLES, 0, 3);
     };
@@ -154,13 +122,10 @@ export default function LandscapeBg({ spaceMode = false }) {
 
     const play = () => {
       if (frame || reduceMotion.matches || document.hidden) return;
-      // Rebase so the scene doesn't jump forward by however long we paused.
       start = performance.now() - elapsed * 1000;
       frame = requestAnimationFrame(loop);
     };
 
-    // Burning battery on an ambient background in a tab nobody is looking at
-    // is pure waste.
     const onVisibility = () => (document.hidden ? stop() : play());
     const onMotionChange = () => (reduceMotion.matches ? (stop(), draw()) : play());
     const onResize = () => {
@@ -194,8 +159,6 @@ export default function LandscapeBg({ spaceMode = false }) {
     };
   }, []);
 
-  // Forces a redraw the instant spaceMode changes, in case no rAF loop is
-  // currently running to pick it up on its own (see drawRef's comment above).
   useEffect(() => {
     drawRef.current?.();
   }, [spaceMode]);

--- a/src/components/RainforestBg.jsx
+++ b/src/components/RainforestBg.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
 import vertSource from '../shaders/landscape.vert?raw';
 import commonSource from '../shaders/common.glsl?raw';
-import themeFragSource from '../shaders/landscape.frag?raw';
+import themeFragSource from '../shaders/rainforest.frag?raw';
 import { createSpaceRamp } from '../spaceRamp.js';
 import styles from './LandscapeBg.module.scss';
 
@@ -9,23 +9,8 @@ import styles from './LandscapeBg.module.scss';
 // concatenates ahead of its own scene-specific source before compiling.
 const fragSource = `${commonSource}\n${themeFragSource}`;
 
-// Ridge silhouettes have hard edges, so full retina resolution is visibly
-// sharper than a plain gradient would justify — render at the device's
-// actual pixel density rather than downsampling. Capped at 3 purely as a
-// safety ceiling against pathological values (e.g. browser zoom inflating
-// devicePixelRatio well past what any real display panel uses).
+// See LandscapeBg.jsx's identical constant for the reasoning.
 const MAX_DPR = 3;
-// A stylized day, not a real 24-hour one — fast enough that the sun's drift
-// is noticeable within a normal page visit, slow enough to still read as
-// ambient rather than an obvious animation.
-const SUN_CYCLE_MS = 3 * 60 * 1000;
-
-// Phase of the current cycle elapsed (0..1) — real wall-clock time, not
-// performance.now(), so every visitor's sun sits at the same height at a
-// given moment regardless of when their own session started.
-function sunCyclePhase() {
-  return (Date.now() % SUN_CYCLE_MS) / SUN_CYCLE_MS;
-}
 
 function compile(gl, type, source) {
   const shader = gl.createShader(type);
@@ -46,8 +31,6 @@ function createProgram(gl) {
   gl.attachShader(program, vert);
   gl.attachShader(program, frag);
   gl.linkProgram(program);
-  // Attached shaders stay alive until the program is deleted, so they can be
-  // released as soon as the link succeeds.
   gl.deleteShader(vert);
   gl.deleteShader(frag);
   if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
@@ -58,24 +41,14 @@ function createProgram(gl) {
   return program;
 }
 
-// If anything below fails the canvas is simply never painted. It stays
-// transparent, so the app's gradient shows through untouched — no state and
-// no fallback branch needed.
-export default function LandscapeBg({ spaceMode = false }) {
+// Same lifecycle shape as LandscapeBg.jsx (webgl2/webgl fallback,
+// reduced-motion, visibility pause, context-loss, full teardown) — this
+// scene has no day/night cycle of its own, so there's no uSunPhase.
+export default function RainforestBg({ spaceMode = false }) {
   const canvasRef = useRef(null);
-  // Read fresh inside the mount effect's rAF loop (which never re-runs while
-  // this component stays mounted) rather than closing over the prop's
-  // initial value — see createSpaceRamp's caller below.
   const spaceModeRef = useRef(spaceMode);
-  // Holds the mount effect's own `draw`, so the effect below can force one
-  // redraw right when spaceMode flips even if no rAF loop is running (e.g.
-  // reduced motion) — otherwise the canvas would just keep showing whatever
-  // it last drew until something else happened to trigger a frame.
   const drawRef = useRef(null);
 
-  // Writing a ref during render is disallowed (react-hooks/refs) — this
-  // effect is the safe place, and runs before the "force a redraw" effect
-  // below since effects commit in declaration order.
   useEffect(() => {
     spaceModeRef.current = spaceMode;
   }, [spaceMode]);
@@ -94,7 +67,6 @@ export default function LandscapeBg({ spaceMode = false }) {
     try {
       program = createProgram(gl);
     } catch {
-      // A driver that can't compile this leaves the gradient in place.
       return undefined;
     }
 
@@ -106,7 +78,6 @@ export default function LandscapeBg({ spaceMode = false }) {
     const uResolution = gl.getUniformLocation(program, 'uResolution');
     const uTime = gl.getUniformLocation(program, 'uTime');
     const uSeed = gl.getUniformLocation(program, 'uSeed');
-    const uSunPhase = gl.getUniformLocation(program, 'uSunPhase');
     const uSpaceT = gl.getUniformLocation(program, 'uSpaceT');
     const spaceT = createSpaceRamp(spaceModeRef.current);
 
@@ -129,14 +100,11 @@ export default function LandscapeBg({ spaceMode = false }) {
     const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
     let frame = 0;
     let start = performance.now();
-    // Frozen time for reduced motion still renders the full scene, just
-    // without the drift.
     let elapsed = 0;
 
     const draw = () => {
       resize();
       gl.uniform1f(uTime, elapsed);
-      gl.uniform1f(uSunPhase, sunCyclePhase());
       gl.uniform1f(uSpaceT, spaceT(spaceModeRef.current));
       gl.drawArrays(gl.TRIANGLES, 0, 3);
     };
@@ -154,13 +122,10 @@ export default function LandscapeBg({ spaceMode = false }) {
 
     const play = () => {
       if (frame || reduceMotion.matches || document.hidden) return;
-      // Rebase so the scene doesn't jump forward by however long we paused.
       start = performance.now() - elapsed * 1000;
       frame = requestAnimationFrame(loop);
     };
 
-    // Burning battery on an ambient background in a tab nobody is looking at
-    // is pure waste.
     const onVisibility = () => (document.hidden ? stop() : play());
     const onMotionChange = () => (reduceMotion.matches ? (stop(), draw()) : play());
     const onResize = () => {
@@ -194,8 +159,6 @@ export default function LandscapeBg({ spaceMode = false }) {
     };
   }, []);
 
-  // Forces a redraw the instant spaceMode changes, in case no rAF loop is
-  // currently running to pick it up on its own (see drawRef's comment above).
   useEffect(() => {
     drawRef.current?.();
   }, [spaceMode]);

--- a/src/components/RainforestBg.jsx
+++ b/src/components/RainforestBg.jsx
@@ -3,6 +3,7 @@ import vertSource from '../shaders/landscape.vert?raw';
 import commonSource from '../shaders/common.glsl?raw';
 import themeFragSource from '../shaders/rainforest.frag?raw';
 import { createSpaceRamp } from '../spaceRamp.js';
+import { getSceneSeed } from '../seed.js';
 import styles from './LandscapeBg.module.scss';
 
 // common.glsl isn't a real GLSL module — just a text prefix every theme
@@ -84,7 +85,7 @@ export default function RainforestBg({ spaceMode = false }) {
     gl.useProgram(program);
     gl.enableVertexAttribArray(aPosition);
     gl.vertexAttribPointer(aPosition, 2, gl.FLOAT, false, 0, 0);
-    gl.uniform1f(uSeed, Math.random() * 100);
+    gl.uniform1f(uSeed, getSceneSeed());
 
     const resize = () => {
       const dpr = Math.min(window.devicePixelRatio || 1, MAX_DPR);

--- a/src/components/StartActions.jsx
+++ b/src/components/StartActions.jsx
@@ -1,6 +1,7 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faShower, faPanorama } from '@fortawesome/free-solid-svg-icons';
+import { faShower, faRocket } from '@fortawesome/free-solid-svg-icons';
 import { TOOLTIP_ID } from '../constants.js';
+import BackgroundMenu from './BackgroundMenu.jsx';
 import styles from './StartActions.module.scss';
 
 function clearCache() {
@@ -8,40 +9,42 @@ function clearCache() {
   window.location.reload();
 }
 
-export default function StartActions({ backgroundThemeLabel, onCycleBackground }) {
-  const actions = [
-    {
-      name: 'Clear Cache',
-      action: clearCache,
-      icon: faShower,
-      tooltip: 'Clean Caches',
-    },
-    {
-      name: 'Change Background',
-      action: onCycleBackground,
-      icon: faPanorama,
-      tooltip: `Background: ${backgroundThemeLabel}`,
-    },
-  ];
-
+// The background control isn't a one-shot action like the other two (it's a
+// stateful dropdown), so it renders as its own <BackgroundMenu> in the same
+// taskbar slot rather than living in a generic action list.
+export default function StartActions({
+  themes,
+  activeThemeId,
+  onSelectTheme,
+  spaceMode,
+  onToggleSpaceMode,
+}) {
   return (
     <div className={styles.actions}>
-      {actions
-        .filter((action) => action.icon)
-        .map((action) => (
-          <button
-            key={action.name}
-            type="button"
-            aria-label={action.name}
-            className={styles.action}
-            onClick={action.action}
-            data-tooltip-id={TOOLTIP_ID}
-            data-tooltip-content={action.tooltip}
-            data-tooltip-place="top-start"
-          >
-            <FontAwesomeIcon icon={action.icon} />
-          </button>
-        ))}
+      <button
+        type="button"
+        aria-label="Clear Cache"
+        className={styles.action}
+        onClick={clearCache}
+        data-tooltip-id={TOOLTIP_ID}
+        data-tooltip-content="Clean Caches"
+        data-tooltip-place="top-start"
+      >
+        <FontAwesomeIcon icon={faShower} />
+      </button>
+      <BackgroundMenu themes={themes} activeId={activeThemeId} onSelect={onSelectTheme} />
+      <button
+        type="button"
+        aria-label="Space Mode"
+        aria-pressed={spaceMode}
+        className={styles.action}
+        onClick={onToggleSpaceMode}
+        data-tooltip-id={TOOLTIP_ID}
+        data-tooltip-content={`Space Mode: ${spaceMode ? 'On' : 'Off'}`}
+        data-tooltip-place="top-start"
+      >
+        <FontAwesomeIcon icon={faRocket} />
+      </button>
     </div>
   );
 }

--- a/src/components/StartActions.jsx
+++ b/src/components/StartActions.jsx
@@ -1,6 +1,5 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faShower, faRocket } from '@fortawesome/free-solid-svg-icons';
-import { TOOLTIP_ID } from '../constants.js';
 import BackgroundMenu from './BackgroundMenu.jsx';
 import styles from './StartActions.module.scss';
 
@@ -21,15 +20,7 @@ export default function StartActions({
 }) {
   return (
     <div className={styles.actions}>
-      <button
-        type="button"
-        aria-label="Clear Cache"
-        className={styles.action}
-        onClick={clearCache}
-        data-tooltip-id={TOOLTIP_ID}
-        data-tooltip-content="Clean Caches"
-        data-tooltip-place="top-start"
-      >
+      <button type="button" aria-label="Clear Cache" className={styles.action} onClick={clearCache}>
         <FontAwesomeIcon icon={faShower} />
       </button>
       <BackgroundMenu themes={themes} activeId={activeThemeId} onSelect={onSelectTheme} />
@@ -39,9 +30,6 @@ export default function StartActions({
         aria-pressed={spaceMode}
         className={styles.action}
         onClick={onToggleSpaceMode}
-        data-tooltip-id={TOOLTIP_ID}
-        data-tooltip-content={`Space Mode: ${spaceMode ? 'On' : 'Off'}`}
-        data-tooltip-place="top-start"
       >
         <FontAwesomeIcon icon={faRocket} />
       </button>

--- a/src/components/StartActions.module.scss
+++ b/src/components/StartActions.module.scss
@@ -1,3 +1,5 @@
+@use '../styles/variables' as *;
+
 .actions {
   display: flex;
   align-items: center;
@@ -12,4 +14,10 @@
   color: white;
   font-size: 1.5rem;
   line-height: 1;
+
+  // A persistent cue for toggles (space mode), beyond just the tooltip —
+  // the two other buttons here are one-shot actions and never get this.
+  &[aria-pressed='true'] {
+    color: $accent;
+  }
 }

--- a/src/components/StartButton.jsx
+++ b/src/components/StartButton.jsx
@@ -1,4 +1,3 @@
-import { TOOLTIP_ID } from '../constants.js';
 import logo from '../assets/img/lucasrasmussen-logo.svg';
 import styles from './StartButton.module.scss';
 
@@ -6,16 +5,7 @@ export default function StartButton({ expanded, onToggle, ref }) {
   const label = expanded ? 'Close Résumé' : 'Open Résumé';
 
   return (
-    <button
-      ref={ref}
-      type="button"
-      className={styles.button}
-      onClick={onToggle}
-      aria-label={label}
-      data-tooltip-id={TOOLTIP_ID}
-      data-tooltip-content={label}
-      data-tooltip-place="top-end"
-    >
+    <button ref={ref} type="button" className={styles.button} onClick={onToggle} aria-label={label}>
       <img src={logo} alt="" />
     </button>
   );

--- a/src/components/StartMenu.jsx
+++ b/src/components/StartMenu.jsx
@@ -7,15 +7,21 @@ export default function StartMenu({
   onToggle,
   buttonRef,
   ref,
-  backgroundThemeLabel,
-  onCycleBackground,
+  themes,
+  activeThemeId,
+  onSelectTheme,
+  spaceMode,
+  onToggleSpaceMode,
 }) {
   return (
     <div className={styles.start} ref={ref}>
       <StartButton expanded={expanded} onToggle={onToggle} ref={buttonRef} />
       <StartActions
-        backgroundThemeLabel={backgroundThemeLabel}
-        onCycleBackground={onCycleBackground}
+        themes={themes}
+        activeThemeId={activeThemeId}
+        onSelectTheme={onSelectTheme}
+        spaceMode={spaceMode}
+        onToggleSpaceMode={onToggleSpaceMode}
       />
     </div>
   );

--- a/src/components/TundraBg.jsx
+++ b/src/components/TundraBg.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
 import vertSource from '../shaders/landscape.vert?raw';
 import commonSource from '../shaders/common.glsl?raw';
-import themeFragSource from '../shaders/landscape.frag?raw';
+import themeFragSource from '../shaders/tundra.frag?raw';
 import { createSpaceRamp } from '../spaceRamp.js';
 import styles from './LandscapeBg.module.scss';
 
@@ -9,23 +9,8 @@ import styles from './LandscapeBg.module.scss';
 // concatenates ahead of its own scene-specific source before compiling.
 const fragSource = `${commonSource}\n${themeFragSource}`;
 
-// Ridge silhouettes have hard edges, so full retina resolution is visibly
-// sharper than a plain gradient would justify — render at the device's
-// actual pixel density rather than downsampling. Capped at 3 purely as a
-// safety ceiling against pathological values (e.g. browser zoom inflating
-// devicePixelRatio well past what any real display panel uses).
+// See LandscapeBg.jsx's identical constant for the reasoning.
 const MAX_DPR = 3;
-// A stylized day, not a real 24-hour one — fast enough that the sun's drift
-// is noticeable within a normal page visit, slow enough to still read as
-// ambient rather than an obvious animation.
-const SUN_CYCLE_MS = 3 * 60 * 1000;
-
-// Phase of the current cycle elapsed (0..1) — real wall-clock time, not
-// performance.now(), so every visitor's sun sits at the same height at a
-// given moment regardless of when their own session started.
-function sunCyclePhase() {
-  return (Date.now() % SUN_CYCLE_MS) / SUN_CYCLE_MS;
-}
 
 function compile(gl, type, source) {
   const shader = gl.createShader(type);
@@ -46,8 +31,6 @@ function createProgram(gl) {
   gl.attachShader(program, vert);
   gl.attachShader(program, frag);
   gl.linkProgram(program);
-  // Attached shaders stay alive until the program is deleted, so they can be
-  // released as soon as the link succeeds.
   gl.deleteShader(vert);
   gl.deleteShader(frag);
   if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
@@ -58,24 +41,14 @@ function createProgram(gl) {
   return program;
 }
 
-// If anything below fails the canvas is simply never painted. It stays
-// transparent, so the app's gradient shows through untouched — no state and
-// no fallback branch needed.
-export default function LandscapeBg({ spaceMode = false }) {
+// Same lifecycle shape as LandscapeBg.jsx (webgl2/webgl fallback,
+// reduced-motion, visibility pause, context-loss, full teardown) — this
+// scene is a fixed polar night, so there's no uSunPhase.
+export default function TundraBg({ spaceMode = false }) {
   const canvasRef = useRef(null);
-  // Read fresh inside the mount effect's rAF loop (which never re-runs while
-  // this component stays mounted) rather than closing over the prop's
-  // initial value — see createSpaceRamp's caller below.
   const spaceModeRef = useRef(spaceMode);
-  // Holds the mount effect's own `draw`, so the effect below can force one
-  // redraw right when spaceMode flips even if no rAF loop is running (e.g.
-  // reduced motion) — otherwise the canvas would just keep showing whatever
-  // it last drew until something else happened to trigger a frame.
   const drawRef = useRef(null);
 
-  // Writing a ref during render is disallowed (react-hooks/refs) — this
-  // effect is the safe place, and runs before the "force a redraw" effect
-  // below since effects commit in declaration order.
   useEffect(() => {
     spaceModeRef.current = spaceMode;
   }, [spaceMode]);
@@ -94,7 +67,6 @@ export default function LandscapeBg({ spaceMode = false }) {
     try {
       program = createProgram(gl);
     } catch {
-      // A driver that can't compile this leaves the gradient in place.
       return undefined;
     }
 
@@ -106,7 +78,6 @@ export default function LandscapeBg({ spaceMode = false }) {
     const uResolution = gl.getUniformLocation(program, 'uResolution');
     const uTime = gl.getUniformLocation(program, 'uTime');
     const uSeed = gl.getUniformLocation(program, 'uSeed');
-    const uSunPhase = gl.getUniformLocation(program, 'uSunPhase');
     const uSpaceT = gl.getUniformLocation(program, 'uSpaceT');
     const spaceT = createSpaceRamp(spaceModeRef.current);
 
@@ -129,14 +100,11 @@ export default function LandscapeBg({ spaceMode = false }) {
     const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
     let frame = 0;
     let start = performance.now();
-    // Frozen time for reduced motion still renders the full scene, just
-    // without the drift.
     let elapsed = 0;
 
     const draw = () => {
       resize();
       gl.uniform1f(uTime, elapsed);
-      gl.uniform1f(uSunPhase, sunCyclePhase());
       gl.uniform1f(uSpaceT, spaceT(spaceModeRef.current));
       gl.drawArrays(gl.TRIANGLES, 0, 3);
     };
@@ -154,13 +122,10 @@ export default function LandscapeBg({ spaceMode = false }) {
 
     const play = () => {
       if (frame || reduceMotion.matches || document.hidden) return;
-      // Rebase so the scene doesn't jump forward by however long we paused.
       start = performance.now() - elapsed * 1000;
       frame = requestAnimationFrame(loop);
     };
 
-    // Burning battery on an ambient background in a tab nobody is looking at
-    // is pure waste.
     const onVisibility = () => (document.hidden ? stop() : play());
     const onMotionChange = () => (reduceMotion.matches ? (stop(), draw()) : play());
     const onResize = () => {
@@ -194,8 +159,6 @@ export default function LandscapeBg({ spaceMode = false }) {
     };
   }, []);
 
-  // Forces a redraw the instant spaceMode changes, in case no rAF loop is
-  // currently running to pick it up on its own (see drawRef's comment above).
   useEffect(() => {
     drawRef.current?.();
   }, [spaceMode]);

--- a/src/components/TundraBg.jsx
+++ b/src/components/TundraBg.jsx
@@ -3,6 +3,7 @@ import vertSource from '../shaders/landscape.vert?raw';
 import commonSource from '../shaders/common.glsl?raw';
 import themeFragSource from '../shaders/tundra.frag?raw';
 import { createSpaceRamp } from '../spaceRamp.js';
+import { getSceneSeed } from '../seed.js';
 import styles from './LandscapeBg.module.scss';
 
 // common.glsl isn't a real GLSL module — just a text prefix every theme
@@ -84,7 +85,7 @@ export default function TundraBg({ spaceMode = false }) {
     gl.useProgram(program);
     gl.enableVertexAttribArray(aPosition);
     gl.vertexAttribPointer(aPosition, 2, gl.FLOAT, false, 0, 0);
-    gl.uniform1f(uSeed, Math.random() * 100);
+    gl.uniform1f(uSeed, getSceneSeed());
 
     const resize = () => {
       const dpr = Math.min(window.devicePixelRatio || 1, MAX_DPR);

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,3 +1,0 @@
-// Single shared react-tooltip instance, referenced by every element that wants
-// a tooltip via `data-tooltip-id`.
-export const TOOLTIP_ID = 'app-tooltip';

--- a/src/seed.js
+++ b/src/seed.js
@@ -1,0 +1,32 @@
+// Persists a single procedural-generation seed across reloads, so a theme's
+// specific arrangement (palette, ridge/dune/wave/aurora shapes, sun/planet
+// placement, etc.) stays the same between visits — reloading only moves
+// what's genuinely time-based (the sun's day/night cycle, ambient drift).
+// "Clear Cache" already wipes all of localStorage and reloads, which
+// naturally rerolls this too, so it doesn't need its own reset path.
+const STORAGE_KEY = 'lr-scene-seed';
+
+let cachedSeed = null;
+
+export function getSceneSeed() {
+  if (cachedSeed !== null) return cachedSeed;
+
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    const parsed = stored === null ? NaN : Number(stored);
+    if (Number.isFinite(parsed)) {
+      cachedSeed = parsed;
+      return cachedSeed;
+    }
+  } catch {
+    // Storage disabled/unavailable — fall through to a fresh, unpersisted seed.
+  }
+
+  cachedSeed = Math.random() * 100;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, String(cachedSeed));
+  } catch {
+    // Best-effort; a disabled/full localStorage just means it won't persist.
+  }
+  return cachedSeed;
+}

--- a/src/shaders/burn.frag
+++ b/src/shaders/burn.frag
@@ -69,7 +69,7 @@ void main() {
 
   // Positive: not yet burned. Negative: already gone.
   float dist = (front + roughness) - uProgress;
-  float edgeWidth = 0.05;
+  float edgeWidth = 0.075;
 
   // Curl: just ahead of the front, warp the sampled texture coordinate
   // toward the ignition point and darken slightly, so the paper reads as
@@ -95,15 +95,19 @@ void main() {
   }
 
   if (dist > 0.0) {
-    // Active ember edge: blend toward a hot core. uProgress itself
-    // advances every frame, so sampling noise against it gives a genuine
-    // flicker rather than a static gradient.
+    // Active ember edge: blend toward a hot core, plus a genuine additive
+    // bloom right at the peak so the hottest point actually reads as
+    // blown-out bright rather than just a flat saturated color. uProgress
+    // itself advances every frame, so sampling noise against it gives a
+    // real flicker rather than a static gradient.
     float edgeT = 1.0 - dist / edgeWidth;
     float flicker = fbm2(auv * 30.0 + uProgress * 40.0 + uSeed * 7.0);
-    vec3 emberCore = vec3(1.0, 0.92, 0.55);
-    vec3 emberOuter = vec3(0.85, 0.22, 0.05);
-    vec3 ember = mix(emberOuter, emberCore, clamp(flicker * 1.4, 0.0, 1.0));
-    gl_FragColor = vec4(mix(src.rgb, ember, edgeT), src.a);
+    vec3 emberCore = vec3(1.0, 0.75, 0.15);
+    vec3 emberOuter = vec3(0.95, 0.12, 0.02);
+    vec3 ember = mix(emberOuter, emberCore, clamp(flicker * 1.5, 0.0, 1.0));
+    vec3 blended = mix(src.rgb, ember, edgeT);
+    blended += ember * pow(edgeT, 1.5) * 0.55;
+    gl_FragColor = vec4(blended, src.a);
     return;
   }
 
@@ -114,20 +118,21 @@ void main() {
   vec3 charColor = mix(vec3(0.05, 0.03, 0.02), vec3(0.0), charT);
   float charAlpha = src.a * (1.0 - smoothstep(0.0, 1.0, charT));
 
-  // Smoke: a wispy trail that rises just behind the char front and lingers
-  // after the paper there is already fully gone, independent of charAlpha
-  // (which has already faded to 0 by this point). `age` is how far past the
-  // front this pixel sits — a stand-in for "how long ago this patch burned",
-  // since a stateless per-pixel shader has no real burn history to read.
-  // The envelope rises fast, then decays over roughly half a burn-duration
-  // so the last patch to burn still gets time to visibly dissipate before
-  // BurnTransition's completion cutoff (see finishAt in BurnTransition.jsx).
+  // Smoke: a thick wispy trail that rises just behind the char front and
+  // lingers well after the paper there is already fully gone, independent
+  // of charAlpha (which has already faded to 0 by this point). `age` is how
+  // far past the front this pixel sits — a stand-in for "how long ago this
+  // patch burned", since a stateless per-pixel shader has no real burn
+  // history to read. The envelope rises fast, then decays slowly enough
+  // that every burn visibly leaves smoke behind rather than a quick wisp;
+  // BurnTransition's completion cutoff (finishAt) is sized to give the last
+  // patch to burn time to fully dissipate before it fires.
   float age = -dist;
-  float envelope = smoothstep(0.0, 0.04, age) * exp(-age * 6.0);
+  float envelope = smoothstep(0.0, 0.04, age) * exp(-age * 3.3);
   vec2 driftUv = auv * 5.0 + vec2(0.6, -1.0) * (age + uProgress * 0.6) + uSeed * 23.0;
   float wisp = fbm2(driftUv);
-  wisp = smoothstep(0.4, 0.8, wisp);
-  float smokeAlpha = envelope * wisp * 0.32;
+  wisp = smoothstep(0.35, 0.75, wisp);
+  float smokeAlpha = envelope * wisp * 0.5;
   vec3 smokeColor = vec3(0.5, 0.49, 0.47);
 
   vec3 finalColor = mix(charColor, smokeColor, smokeAlpha);

--- a/src/shaders/common.glsl
+++ b/src/shaders/common.glsl
@@ -1,0 +1,92 @@
+// Shared procedural-background primitives: hashing/noise/fbm helpers plus a
+// couple of small "sky object" helpers (stars, a generic glowing disc for
+// suns/moons/planets) reused across every background theme. Plain GLSL
+// functions, no preprocessor or real module system — each theme component
+// concatenates this file's ?raw-imported source as a text prefix onto its
+// own frag source before compiling (see e.g. DesertBg.jsx). Declares
+// `precision highp float;` once since it's always prepended first.
+precision highp float;
+
+float hash11(float p) {
+  p = fract(p * 0.1031);
+  p *= p + 33.33;
+  p *= p + p;
+  return fract(p);
+}
+
+float hash21(vec2 p) {
+  vec3 p3 = fract(vec3(p.xyx) * 0.1031);
+  p3 += dot(p3, p3.yzx + 33.33);
+  return fract((p3.x + p3.y) * p3.z);
+}
+
+float valueNoise(float x) {
+  float i = floor(x);
+  float f = fract(x);
+  float u = f * f * (3.0 - 2.0 * f);
+  return mix(hash11(i), hash11(i + 1.0), u);
+}
+
+float noise2(vec2 p) {
+  vec2 i = floor(p);
+  vec2 f = fract(p);
+  vec2 u = f * f * (3.0 - 2.0 * f);
+  return mix(
+    mix(hash21(i), hash21(i + vec2(1.0, 0.0)), u.x),
+    mix(hash21(i + vec2(0.0, 1.0)), hash21(i + vec2(1.0, 1.0)), u.x),
+    u.y
+  );
+}
+
+// The 1 - |2n - 1| fold is what turns rolling hills into sharp ridge lines —
+// used by any theme whose foreground is a height-field silhouette (sunset's
+// mountains, desert's dunes, ocean's waves, tundra's ice horizon).
+float ridgeFbm(float x) {
+  float sum = 0.0;
+  float amp = 0.5;
+  for (int i = 0; i < 5; i++) {
+    float n = valueNoise(x);
+    n = 1.0 - abs(n * 2.0 - 1.0);
+    sum += n * amp;
+    x = x * 2.0 + 11.7;
+    amp *= 0.5;
+  }
+  return sum;
+}
+
+float fbm2(vec2 p) {
+  float sum = 0.0;
+  float amp = 0.5;
+  for (int i = 0; i < 5; i++) {
+    sum += noise2(p) * amp;
+    p = p * 2.0 + 17.0;
+    amp *= 0.5;
+  }
+  return sum;
+}
+
+// Sparse point stars: a cell is a star only if its hash clears a
+// density-driven threshold, so density stays low without a separate
+// probability pass. `seed` shifts the cell lattice so different
+// themes/loads don't line up on the same points.
+float starField(vec2 uv, float seed, float density) {
+  vec2 cell = uv * 220.0 + seed * 41.0;
+  vec2 id = floor(cell);
+  vec2 f = fract(cell) - 0.5;
+  float h = hash21(id);
+  if (h < 1.0 - density) return 0.0;
+  float twinkle = 0.6 + 0.4 * hash21(id + 3.7);
+  return smoothstep(0.5, 0.0, length(f)) * twinkle;
+}
+
+// A soft-glow disc: `x` is an additive glow intensity (unbounded, meant to
+// be multiplied by a color and added), `y` is a 0..1 hard-core mask (meant
+// to be used as a mix() factor toward the body's own color) — the same
+// two-part composition the original sunset sun used inline, generalized so
+// every theme's suns/moons/planets read consistently.
+vec2 celestialBody(vec2 uv, vec2 center, float radius, float glowStrength) {
+  float d = length(uv - center);
+  float glow = exp(-d * (0.5 / radius)) * glowStrength;
+  float core = smoothstep(radius * 1.155, radius * 0.888, d);
+  return vec2(glow, core);
+}

--- a/src/shaders/desert.frag
+++ b/src/shaders/desert.frag
@@ -78,12 +78,33 @@ void main() {
   float ringMask =
     smoothstep(planetRadius * 1.55, planetRadius * 1.7, ringDist) *
     smoothstep(planetRadius * 2.5, planetRadius * 2.25, ringDist);
-  vec2 planet = celestialBody(auv, planetCenter, planetRadius, 0.2);
-  vec3 ringColor = vec3(0.68, 0.58, 0.52);
-  vec3 planetColor = vec3(0.78, 0.58, 0.46);
+
+  // The planet isn't self-luminous like a sun/moon, so it's lit rather than
+  // flat-colored: fake sphere geometry from the flat disc (a hemisphere's
+  // height at each point) and shade it against the actual direction to the
+  // sun in this scene, giving a real day/night terminator rather than a
+  // uniformly-bright disc.
+  float distToPlanet = length(planetUv);
+  float planetMask = smoothstep(planetRadius * 1.04, planetRadius * 0.94, distToPlanet);
+  vec2 pNorm = planetUv / planetRadius;
+  float sphereZ = sqrt(max(0.0, 1.0 - dot(pNorm, pNorm)));
+  vec3 sphereNormal = normalize(vec3(pNorm, sphereZ));
+  vec2 sunDir = normalize(sunCenter - planetCenter);
+  vec3 lightDir = normalize(vec3(sunDir, 0.4));
+  float lighting = clamp(dot(sphereNormal, lightDir), 0.0, 1.0);
+  float shade = mix(0.10, 1.0, pow(lighting, 0.8));
+  vec3 planetBase = vec3(0.78, 0.58, 0.46);
+  vec3 planetColor = planetBase * shade;
+  float planetGlow = exp(-distToPlanet * (0.5 / planetRadius)) * 0.15;
+
+  // Same sun direction, applied in-plane to the ring — the side nearer the
+  // sun reads brighter, the far side dimmer.
+  float ringLight = clamp(dot(normalize(planetUv), sunDir) * 0.5 + 0.5, 0.0, 1.0);
+  vec3 ringColor = vec3(0.68, 0.58, 0.52) * mix(0.35, 1.0, ringLight);
+
   col = mix(col, ringColor, ringMask * uSpaceT * 0.55);
-  col += planetColor * planet.x * uSpaceT;
-  col = mix(col, planetColor, planet.y * uSpaceT);
+  col += planetBase * planetGlow * uSpaceT;
+  col = mix(col, planetColor, planetMask * uSpaceT);
 
   vec2 moonA = celestialBody(auv, vec2(0.14 * aspect, HORIZON + 0.44), 0.013, 0.3);
   vec2 moonB = celestialBody(auv, vec2(0.88 * aspect, HORIZON + 0.14), 0.010, 0.3);

--- a/src/shaders/desert.frag
+++ b/src/shaders/desert.frag
@@ -1,0 +1,119 @@
+// Procedural desert dune sea: a bright, pale midday sky over rounded sand
+// ridges, with a wind-ripple texture painted onto each layer's color (not
+// its height) and a touch of horizon heat-shimmer. Noise/fbm/ridge/
+// celestial-body helpers live in common.glsl, concatenated ahead of this
+// source (see DesertBg.jsx). Space mode ("Martian Waste") shifts the sky to
+// a thin rust atmosphere, reddens the sand, and brings in a ringed planet
+// plus two small moons.
+
+uniform vec2 uResolution;
+uniform float uTime;
+uniform float uSeed;
+uniform float uSpaceT; // 0 (normal) -> 1 (space mode), eased in JS
+
+const int LAYERS = 5;
+const float HORIZON = 0.42;
+
+// Rounded dune crests rather than ridgeFbm's sharp mountain tent-fold.
+float duneFbm(float x) {
+  float sum = 0.0;
+  float amp = 0.5;
+  for (int i = 0; i < 5; i++) {
+    float n = smoothstep(0.15, 0.85, valueNoise(x));
+    sum += n * amp;
+    x = x * 2.0 + 11.7;
+    amp *= 0.5;
+  }
+  return sum;
+}
+
+void main() {
+  vec2 uv = gl_FragCoord.xy / uResolution;
+  float aspect = uResolution.x / uResolution.y;
+  vec2 auv = vec2(uv.x * aspect, uv.y);
+
+  vec3 zenith = vec3(0.42, 0.68, 0.92);
+  vec3 mid = vec3(0.78, 0.85, 0.90);
+  vec3 horizonCol = vec3(0.96, 0.80, 0.55);
+  vec3 sunCol = vec3(1.0, 0.98, 0.88);
+  vec3 farDune = horizonCol * 0.92;
+  vec3 nearDune = vec3(0.58, 0.36, 0.17);
+
+  // Space mode recolors toward a thin rust/mauve Martian atmosphere.
+  vec3 spaceZenith = vec3(0.20, 0.08, 0.14);
+  vec3 spaceMid = vec3(0.55, 0.28, 0.24);
+  vec3 spaceHorizon = vec3(0.78, 0.42, 0.30);
+  vec3 spaceNearDune = vec3(0.62, 0.22, 0.12);
+  zenith = mix(zenith, spaceZenith, uSpaceT);
+  mid = mix(mid, spaceMid, uSpaceT);
+  horizonCol = mix(horizonCol, spaceHorizon, uSpaceT);
+  farDune = mix(farDune, spaceHorizon * 0.85, uSpaceT);
+  nearDune = mix(nearDune, spaceNearDune, uSpaceT);
+
+  // Heat shimmer: a small noise-driven wobble of the horizon threshold,
+  // strongest right at the skyline and fading upward.
+  float shimmerBand = smoothstep(HORIZON + 0.12, HORIZON - 0.02, uv.y);
+  float heat = (fbm2(vec2(auv.x * 4.0 + uTime * 1.1, uv.y * 30.0)) - 0.5) * 0.02 * shimmerBand;
+
+  float sky = smoothstep(HORIZON - 0.05 + heat, 1.0, uv.y);
+  vec3 col = mix(horizonCol, mid, pow(sky, 0.6));
+  col = mix(col, zenith, pow(sky, 1.8));
+
+  float starMask = smoothstep(0.35, 0.7, sky) * uSpaceT;
+  col += vec3(0.95, 0.9, 1.0) * starField(auv, uSeed + 50.0, 0.005) * starMask;
+
+  // Sun: fixed high in the sky (this is a blazing-midday scene, not a
+  // day/night one) with only horizontal seed-driven variety.
+  float sunX = 0.20 + fract(uSeed * 6.13) * 0.6;
+  vec2 sunCenter = vec2(sunX * aspect, 0.86);
+  vec2 sun = celestialBody(auv, sunCenter, 0.05, 0.4);
+  col += sunCol * sun.x * (1.0 - uSpaceT * 0.4);
+  col = mix(col, sunCol, sun.y);
+
+  // Space mode: a ringed planet opposite the sun, plus two small moons.
+  vec2 planetCenter = vec2((1.0 - sunX) * aspect, HORIZON + 0.32);
+  vec2 planetUv = auv - planetCenter;
+  float ringDist = length(vec2(planetUv.x, planetUv.y * 2.4));
+  float planetRadius = 0.052;
+  float ringMask =
+    smoothstep(planetRadius * 1.55, planetRadius * 1.7, ringDist) *
+    smoothstep(planetRadius * 2.5, planetRadius * 2.25, ringDist);
+  vec2 planet = celestialBody(auv, planetCenter, planetRadius, 0.2);
+  vec3 ringColor = vec3(0.68, 0.58, 0.52);
+  vec3 planetColor = vec3(0.78, 0.58, 0.46);
+  col = mix(col, ringColor, ringMask * uSpaceT * 0.55);
+  col += planetColor * planet.x * uSpaceT;
+  col = mix(col, planetColor, planet.y * uSpaceT);
+
+  vec2 moonA = celestialBody(auv, vec2(0.14 * aspect, HORIZON + 0.44), 0.013, 0.3);
+  vec2 moonB = celestialBody(auv, vec2(0.88 * aspect, HORIZON + 0.14), 0.010, 0.3);
+  vec3 moonColor = vec3(0.86, 0.84, 0.80);
+  col += moonColor * (moonA.x + moonB.x) * uSpaceT;
+  col = mix(col, moonColor, max(moonA.y, moonB.y) * uSpaceT);
+
+  // Dune layers, painted far to near.
+  for (int i = 0; i < LAYERS; i++) {
+    float t = float(i) / float(LAYERS - 1);
+
+    float freq = mix(1.6, 0.6, t);
+    float amp = mix(0.022, 0.10, t);
+    float base = mix(HORIZON - 0.006, HORIZON - 0.16, t);
+    float speed = mix(0.0015, 0.0110, t);
+
+    float x = auv.x * freq + uTime * speed + uSeed * 9.0 + float(i) * 19.3;
+    float h = base + duneFbm(x) * amp;
+
+    if (uv.y < h) {
+      vec3 ridge = mix(farDune, nearDune, t * t);
+      // Wind-ripple texture painted onto color only, not height.
+      float ripple = fbm2(vec2(auv.x * 42.0 + uSeed * 3.0, uv.y * 42.0 + float(i) * 5.0));
+      ridge *= 0.90 + 0.18 * ripple;
+      ridge *= 0.92 + 0.08 * smoothstep(base - amp, h, uv.y);
+      col = ridge;
+    }
+  }
+
+  col += (hash21(gl_FragCoord.xy) - 0.5) / 255.0;
+
+  gl_FragColor = vec4(col, 1.0);
+}

--- a/src/shaders/landscape.frag
+++ b/src/shaders/landscape.frag
@@ -1,6 +1,7 @@
 // Procedural sunset landscape: layered ridge silhouettes under a graded sky.
-// Everything is generated from uSeed, so every page load is a different scene.
-precision highp float;
+// Everything is generated from uSeed, so every page load is a different
+// scene. Noise/fbm/ridge/celestial-body helpers live in common.glsl, which
+// LandscapeBg.jsx concatenates ahead of this source before compiling.
 
 uniform vec2 uResolution;
 uniform float uTime;
@@ -10,67 +11,11 @@ uniform float uSeed;
 // visitor at a given moment rather than randomized per load, and its drift
 // is slow enough to read as ambient rather than an obvious animation.
 uniform float uSunPhase;
+// 0 (normal) -> 1 (space mode): eased in JS, see LandscapeBg.jsx.
+uniform float uSpaceT;
 
 const int LAYERS = 6;
 const float HORIZON = 0.46;
-
-// --- noise -------------------------------------------------------------
-
-float hash11(float p) {
-  p = fract(p * 0.1031);
-  p *= p + 33.33;
-  p *= p + p;
-  return fract(p);
-}
-
-float hash21(vec2 p) {
-  vec3 p3 = fract(vec3(p.xyx) * 0.1031);
-  p3 += dot(p3, p3.yzx + 33.33);
-  return fract((p3.x + p3.y) * p3.z);
-}
-
-float valueNoise(float x) {
-  float i = floor(x);
-  float f = fract(x);
-  float u = f * f * (3.0 - 2.0 * f);
-  return mix(hash11(i), hash11(i + 1.0), u);
-}
-
-float noise2(vec2 p) {
-  vec2 i = floor(p);
-  vec2 f = fract(p);
-  vec2 u = f * f * (3.0 - 2.0 * f);
-  return mix(
-    mix(hash21(i), hash21(i + vec2(1.0, 0.0)), u.x),
-    mix(hash21(i + vec2(0.0, 1.0)), hash21(i + vec2(1.0, 1.0)), u.x),
-    u.y
-  );
-}
-
-// The 1 - |2n - 1| fold is what turns rolling hills into sharp ridge lines.
-float ridgeFbm(float x) {
-  float sum = 0.0;
-  float amp = 0.5;
-  for (int i = 0; i < 5; i++) {
-    float n = valueNoise(x);
-    n = 1.0 - abs(n * 2.0 - 1.0);
-    sum += n * amp;
-    x = x * 2.0 + 11.7;
-    amp *= 0.5;
-  }
-  return sum;
-}
-
-float fbm2(vec2 p) {
-  float sum = 0.0;
-  float amp = 0.5;
-  for (int i = 0; i < 5; i++) {
-    sum += noise2(p) * amp;
-    p = p * 2.0 + 17.0;
-    amp *= 0.5;
-  }
-  return sum;
-}
 
 // --- palette -----------------------------------------------------------
 
@@ -132,6 +77,12 @@ void main() {
   vec3 col = mix(pal.horizon, pal.mid, pow(sky, 0.55));
   col = mix(col, pal.zenith, pow(sky, 1.9));
 
+  // Space mode ("Binary Ember"): a faint magenta cast at the zenith and a
+  // scatter of stars wherever the sky is dark enough to show them.
+  col = mix(col, col + vec3(0.10, -0.02, 0.12) * sky, uSpaceT);
+  float starMask = smoothstep(0.35, 0.75, sky) * uSpaceT;
+  col += vec3(0.9, 0.92, 1.0) * starField(uv * vec2(aspect, 1.0), uSeed, 0.006) * starMask;
+
   // Sun, parked just above the horizon. Horizontal placement is still
   // per-load variety from the seed, but height follows a smooth, fast-forward
   // day cycle (see uSunPhase) so it's the same for every visitor watching at
@@ -139,10 +90,18 @@ void main() {
   float sunX = 0.22 + fract(uSeed * 7.31) * 0.56;
   float cycleHeight = 0.5 - 0.5 * cos(uSunPhase * 6.28318530718);
   float sunY = HORIZON + 0.015 + cycleHeight * 0.07;
-  vec2 sunUv = vec2((uv.x - sunX) * aspect, uv.y - sunY);
-  float sunDist = length(sunUv);
-  col += pal.sun * exp(-sunDist * 11.0) * 0.55;
-  col = mix(col, pal.sun, smoothstep(0.052, 0.040, sunDist));
+  vec2 sunCenter = vec2(sunX * aspect, sunY);
+  vec2 sunUv = vec2(uv.x * aspect, uv.y);
+  vec2 sun = celestialBody(sunUv, sunCenter, 0.046, 0.55);
+  col += pal.sun * sun.x;
+  col = mix(col, pal.sun, sun.y);
+
+  // Space mode: a second, smaller, redder companion sun fades in nearby.
+  vec2 companionCenter = sunCenter + vec2(0.10 * aspect, 0.05);
+  vec2 companion = celestialBody(sunUv, companionCenter, 0.026, 0.5);
+  vec3 companionColor = vec3(0.95, 0.18, 0.12);
+  col += companionColor * companion.x * uSpaceT;
+  col = mix(col, companionColor, companion.y * uSpaceT);
 
   // High cloud banding, drifting slower than anything on the ground.
   float cloud = fbm2(vec2(uv.x * aspect * 1.6 + uTime * 0.006 + uSeed * 5.0, uv.y * 3.4));

--- a/src/shaders/ocean.frag
+++ b/src/shaders/ocean.frag
@@ -1,0 +1,110 @@
+// Procedural open ocean: the same layered far-to-near band technique as the
+// sunset/desert/tundra foregrounds, but the ridge height field is replaced
+// with a periodic sine+noise wave field, plus a foam highlight at each
+// crest and a noise-broken sun-glitter streak on the water. Noise/fbm/
+// celestial-body/starField helpers live in common.glsl, concatenated ahead
+// of this source (see OceanBg.jsx). Space mode ("Alien Tide") shifts the sky
+// to a pale green/violet atmosphere with visible stars, adds a second moon
+// (with its own glitter streak), and recolors the foam to glowing cyan.
+
+uniform vec2 uResolution;
+uniform float uTime;
+uniform float uSeed;
+uniform float uSpaceT; // 0 (normal) -> 1 (space mode), eased in JS
+
+const int LAYERS = 6;
+const float HORIZON = 0.52;
+
+// Periodic sine+noise field — waves are regular and repeating, unlike the
+// random-walk ridgeFbm used for mountains/dunes/ice.
+float waveField(float x) {
+  float sum = 0.0;
+  float amp = 0.5;
+  float freq = 1.0;
+  for (int i = 0; i < 5; i++) {
+    sum += sin(x * freq + float(i) * 2.1) * amp;
+    freq *= 1.9;
+    amp *= 0.55;
+  }
+  return sum;
+}
+
+// A noise-broken specular streak beneath a light source, standing in for
+// sunlight/moonlight glinting off chopped water.
+float glitter(vec2 auv, float lightX, float horizonY) {
+  float band = smoothstep(0.09, 0.0, abs(auv.x - lightX));
+  float below = smoothstep(horizonY + 0.02, horizonY - 0.35, auv.y);
+  float sparkle = fbm2(vec2(auv.x * 30.0, auv.y * 40.0 - uTime * 1.5));
+  sparkle = smoothstep(0.55, 0.85, sparkle);
+  return band * below * sparkle;
+}
+
+void main() {
+  vec2 uv = gl_FragCoord.xy / uResolution;
+  float aspect = uResolution.x / uResolution.y;
+  vec2 auv = vec2(uv.x * aspect, uv.y);
+
+  vec3 zenith = vec3(0.04, 0.10, 0.30);
+  vec3 mid = vec3(0.14, 0.34, 0.52);
+  vec3 horizonCol = vec3(0.55, 0.68, 0.68);
+  vec3 sunCol = vec3(1.0, 0.97, 0.85);
+  vec3 farWater = vec3(0.10, 0.32, 0.42);
+  vec3 nearWater = vec3(0.02, 0.10, 0.20);
+  vec3 foamColor = vec3(0.85, 0.95, 0.95);
+
+  vec3 spaceZenith = vec3(0.06, 0.05, 0.18);
+  vec3 spaceMid = vec3(0.20, 0.30, 0.30);
+  vec3 spaceHorizon = vec3(0.55, 0.70, 0.55);
+  vec3 spaceFoam = vec3(0.35, 0.95, 0.90);
+  zenith = mix(zenith, spaceZenith, uSpaceT);
+  mid = mix(mid, spaceMid, uSpaceT);
+  horizonCol = mix(horizonCol, spaceHorizon, uSpaceT);
+  foamColor = mix(foamColor, spaceFoam, uSpaceT);
+
+  float sky = smoothstep(HORIZON - 0.04, 1.0, uv.y);
+  vec3 col = mix(horizonCol, mid, pow(sky, 0.6));
+  col = mix(col, zenith, pow(sky, 1.7));
+
+  float starMask = smoothstep(0.3, 0.7, sky) * uSpaceT;
+  col += vec3(0.9, 0.95, 1.0) * starField(auv, uSeed + 80.0, 0.010) * starMask;
+
+  float sunX = 0.24 + fract(uSeed * 5.47) * 0.55;
+  vec2 sunCenter = vec2(sunX * aspect, HORIZON + 0.20);
+  vec2 sun = celestialBody(auv, sunCenter, 0.045, 0.5);
+  col += sunCol * sun.x;
+  col = mix(col, sunCol, sun.y);
+  col += sunCol * glitter(auv, sunCenter.x, HORIZON) * 0.8;
+
+  // Space mode: a second moon, each light casting its own glitter streak.
+  float moonX = fract(sunX + 0.4) * aspect;
+  vec2 moonCenter = vec2(moonX, HORIZON + 0.30);
+  vec2 moon = celestialBody(auv, moonCenter, 0.028, 0.35);
+  vec3 moonColor = vec3(0.80, 0.85, 0.90);
+  col += moonColor * moon.x * uSpaceT;
+  col = mix(col, moonColor, moon.y * uSpaceT);
+  col += moonColor * glitter(auv, moonCenter.x, HORIZON) * 0.6 * uSpaceT;
+
+  // Wave layers, painted far to near, each with a foam crest highlight.
+  for (int i = 0; i < LAYERS; i++) {
+    float t = float(i) / float(LAYERS - 1);
+
+    float freq = mix(2.6, 1.1, t);
+    float amp = mix(0.012, 0.055, t);
+    float base = mix(HORIZON - 0.006, HORIZON - 0.16, t);
+    float speed = mix(0.5, 1.6, t);
+
+    float x = auv.x * freq + uTime * speed * 0.4 + uSeed * 8.0 + float(i) * 15.7;
+    float h = base + waveField(x) * amp;
+
+    if (uv.y < h) {
+      vec3 water = mix(farWater, nearWater, t * t);
+      float foamT = smoothstep(h - amp * 0.18, h, uv.y);
+      water = mix(water, foamColor, foamT * (0.5 + 0.5 * t));
+      col = water;
+    }
+  }
+
+  col += (hash21(gl_FragCoord.xy) - 0.5) / 255.0;
+
+  gl_FragColor = vec4(col, 1.0);
+}

--- a/src/shaders/rainforest.frag
+++ b/src/shaders/rainforest.frag
@@ -1,0 +1,81 @@
+// Procedural rainforest canopy: looking up through layered masses of
+// foliage rather than a height-silhouette landscape — each layer is a
+// thresholded 2D fbm "blob" field composited far-to-near, so gaps between
+// masses read as bright sky/light shafts rather than a horizon line.
+// Noise/fbm/celestial-body/starField helpers live in common.glsl,
+// concatenated ahead of this source (see RainforestBg.jsx). Space mode
+// ("Bioluminescent Grove") recolors the canopy to glowing cyan/violet,
+// gives the mist a self-glow, adds upward-drifting spore motes, and reveals
+// a striped alien gas giant through the canopy gaps.
+
+uniform vec2 uResolution;
+uniform float uTime;
+uniform float uSeed;
+uniform float uSpaceT; // 0 (normal) -> 1 (space mode), eased in JS
+
+const int LAYERS = 5;
+
+void main() {
+  vec2 uv = gl_FragCoord.xy / uResolution;
+  float aspect = uResolution.x / uResolution.y;
+  vec2 auv = vec2(uv.x * aspect, uv.y);
+
+  vec3 skyGap = vec3(0.75, 0.90, 0.55);
+  vec3 mistColor = vec3(0.55, 0.72, 0.62);
+  vec3 farGreen = vec3(0.10, 0.36, 0.20);
+  vec3 nearGreen = vec3(0.02, 0.15, 0.08);
+
+  vec3 spaceGap = vec3(0.35, 0.85, 0.85);
+  vec3 spaceFar = vec3(0.06, 0.38, 0.48);
+  vec3 spaceNear = vec3(0.16, 0.05, 0.32);
+  skyGap = mix(skyGap, spaceGap, uSpaceT);
+  farGreen = mix(farGreen, spaceFar, uSpaceT);
+  nearGreen = mix(nearGreen, spaceNear, uSpaceT);
+
+  vec3 col = skyGap;
+  float coverage = 0.0;
+
+  for (int i = 0; i < LAYERS; i++) {
+    float t = float(i) / float(LAYERS - 1);
+    vec2 p =
+      auv * mix(1.8, 4.5, t) +
+      vec2(uTime * mix(0.006, 0.03, t) + uSeed * 9.0, uSeed * 13.0 + float(i) * 17.0);
+    float blob = fbm2(p);
+    float threshold = mix(0.62, 0.40, t);
+    float mask = smoothstep(threshold - 0.12, threshold + 0.12, blob);
+    vec3 layerColor = mix(farGreen, nearGreen, t);
+    col = mix(col, layerColor, mask);
+    coverage = max(coverage, mask);
+  }
+
+  float openness = 1.0 - coverage;
+
+  // Scrolling mist, brightest in a mid band, self-glowing in space mode.
+  float mist = fbm2(vec2(auv.x * 2.0 + uTime * 0.02, auv.y * 3.0 - uTime * 0.01));
+  float mistMask = smoothstep(0.0, 0.35, uv.y) * smoothstep(0.55, 0.15, uv.y) * (0.3 + 0.3 * mist);
+  vec3 mistTint = mix(mistColor, vec3(0.40, 0.85, 0.85), uSpaceT);
+  col = mix(col, mistTint, mistMask * 0.5);
+  col += mistTint * mistMask * uSpaceT * 0.4;
+
+  // Light shafts break through wherever the canopy is more open.
+  float shaftNoise = fbm2(vec2(auv.x * 6.0 + uSeed * 4.0, uv.y * 1.0));
+  float shaftMask = smoothstep(0.55, 0.75, shaftNoise) * openness;
+  col += skyGap * shaftMask * 0.3;
+
+  // Space mode: a striped alien gas giant, visible only through the gaps.
+  vec2 planetCenter = vec2(0.68 * aspect, 0.72);
+  vec2 planet = celestialBody(auv, planetCenter, 0.09, 0.15);
+  float stripes = 0.5 + 0.5 * sin((auv.y - planetCenter.y) * 80.0 + uSeed);
+  vec3 planetColor = mix(vec3(0.60, 0.50, 0.72), vec3(0.78, 0.65, 0.85), stripes);
+  float planetVis = uSpaceT * openness;
+  col += planetColor * planet.x * planetVis;
+  col = mix(col, planetColor, planet.y * planetVis);
+
+  // Space mode: upward-drifting bioluminescent spore motes.
+  float motes = starField(auv * 3.0 + vec2(0.0, -uTime * 0.05), uSeed + 70.0, 0.02);
+  col += vec3(0.55, 1.0, 0.90) * motes * uSpaceT;
+
+  col += (hash21(gl_FragCoord.xy) - 0.5) / 255.0;
+
+  gl_FragColor = vec4(col, 1.0);
+}

--- a/src/shaders/tundra.frag
+++ b/src/shaders/tundra.frag
@@ -1,0 +1,87 @@
+// Procedural polar night: a starfield and drifting, domain-warped aurora
+// ribbons over a deep navy/teal/violet sky, with an icy ridge-band horizon
+// silhouette reusing the same technique as the sunset/desert foregrounds.
+// Noise/fbm/ridge/celestial-body/starField helpers live in common.glsl,
+// concatenated ahead of this source (see TundraBg.jsx). Space mode
+// ("Deep Sky") intensifies the aurora with a third electric-magenta hue,
+// thickens the starfield, and brings a large cratered moon low on the
+// horizon.
+
+uniform vec2 uResolution;
+uniform float uTime;
+uniform float uSeed;
+uniform float uSpaceT; // 0 (normal) -> 1 (space mode), eased in JS
+
+const int LAYERS = 5;
+const float HORIZON = 0.34;
+
+// Domain-warped fbm: warping the sample point with a second fbm field is
+// what turns plain noise into flowing, curtain-like ribbons.
+float auroraField(vec2 p, float t) {
+  vec2 warp = vec2(fbm2(p * 0.6 + t * 0.015), fbm2(p * 0.6 + vec2(31.0, 7.0) - t * 0.012));
+  return fbm2(p * 1.3 + warp * 1.6 + vec2(t * 0.035, 0.0));
+}
+
+void main() {
+  vec2 uv = gl_FragCoord.xy / uResolution;
+  float aspect = uResolution.x / uResolution.y;
+  vec2 auv = vec2(uv.x * aspect, uv.y);
+
+  vec3 zenith = vec3(0.02, 0.03, 0.10);
+  vec3 mid = vec3(0.06, 0.10, 0.22);
+  vec3 horizonCol = vec3(0.18, 0.28, 0.40);
+  vec3 farIce = vec3(0.55, 0.68, 0.78);
+  vec3 nearIce = vec3(0.10, 0.16, 0.24);
+
+  float sky = smoothstep(HORIZON - 0.04, 1.0, uv.y);
+  vec3 col = mix(horizonCol, mid, pow(sky, 0.6));
+  col = mix(col, zenith, pow(sky, 1.6));
+
+  // Stars, denser and more color-varied once in space mode.
+  float density = mix(0.010, 0.028, uSpaceT);
+  float star = starField(auv, uSeed, density);
+  vec3 starTint = mix(vec3(0.9, 0.93, 1.0), vec3(0.9 + 0.2 * hash21(floor(auv * 200.0)), 0.85, 1.0), uSpaceT);
+  col += starTint * star * smoothstep(HORIZON + 0.05, HORIZON + 0.4, uv.y);
+
+  // Aurora ribbons drifting across the upper sky.
+  float aurora = auroraField(vec2(auv.x * 1.1 + uSeed * 3.0, uv.y * 2.2), uTime);
+  float band = smoothstep(HORIZON + 0.28, HORIZON + 0.55, uv.y) * smoothstep(1.0, 0.6, uv.y);
+  float auroraMask = smoothstep(0.4, 0.78, aurora) * band;
+  vec3 auroraGreen = vec3(0.30, 0.95, 0.55);
+  vec3 auroraViolet = vec3(0.40, 0.35, 0.92);
+  vec3 auroraMagenta = vec3(0.95, 0.25, 0.75);
+  vec3 auroraColor = mix(auroraViolet, auroraGreen, smoothstep(HORIZON + 0.3, HORIZON + 0.55, uv.y));
+  auroraColor = mix(auroraColor, auroraMagenta, uSpaceT * 0.5);
+  col += auroraColor * auroraMask * mix(0.55, 0.95, uSpaceT);
+
+  // Space mode: a large, low, cratered moon.
+  vec2 moonCenter = vec2(0.72 * aspect, HORIZON + 0.10);
+  vec2 moon = celestialBody(auv, moonCenter, 0.075, 0.18);
+  float craters = fbm2((auv - moonCenter) * 40.0 + uSeed * 5.0);
+  vec3 moonColor = mix(vec3(0.82, 0.80, 0.78), vec3(0.62, 0.60, 0.58), smoothstep(0.35, 0.7, craters));
+  col += moonColor * moon.x * uSpaceT;
+  col = mix(col, moonColor, moon.y * uSpaceT);
+
+  // Icy ridge silhouette, painted far to near.
+  for (int i = 0; i < LAYERS; i++) {
+    float t = float(i) / float(LAYERS - 1);
+
+    float freq = mix(2.0, 0.8, t);
+    float amp = mix(0.018, 0.09, t);
+    float base = mix(HORIZON - 0.008, HORIZON - 0.14, t);
+    float speed = mix(0.0020, 0.0140, t);
+
+    float x = auv.x * freq + uTime * speed + uSeed * 11.0 + float(i) * 23.1;
+    float h = base + ridgeFbm(x) * amp;
+
+    if (uv.y < h) {
+      vec3 ridge = mix(farIce, nearIce, t * t);
+      ridge *= 0.88 + 0.12 * smoothstep(base - amp, h, uv.y);
+      col = ridge;
+    }
+  }
+
+  col += (hash21(gl_FragCoord.xy) - 0.5) / 255.0;
+
+  gl_FragColor = vec4(col, 1.0);
+}

--- a/src/spaceMode.js
+++ b/src/spaceMode.js
@@ -1,0 +1,34 @@
+import { useCallback, useState } from 'react';
+
+// Independent of theme choice (see backgrounds.js) — space mode applies to
+// whichever theme happens to be active, so it's tracked and persisted
+// separately rather than folded into the theme registry.
+const STORAGE_KEY = 'lr-space-mode';
+
+function readStoredSpaceMode() {
+  try {
+    return window.localStorage.getItem(STORAGE_KEY) === '1';
+  } catch {
+    // Storage disabled/unavailable — just fall back, nothing to persist.
+    return false;
+  }
+}
+
+export function useSpaceMode() {
+  const [spaceMode, setSpaceMode] = useState(readStoredSpaceMode);
+
+  const toggleSpaceMode = useCallback(() => {
+    setSpaceMode((current) => {
+      const next = !current;
+      try {
+        window.localStorage.setItem(STORAGE_KEY, next ? '1' : '0');
+      } catch {
+        // Best-effort; a disabled/full localStorage just means the choice
+        // doesn't survive a reload.
+      }
+      return next;
+    });
+  }, []);
+
+  return { spaceMode, toggleSpaceMode };
+}

--- a/src/spaceRamp.js
+++ b/src/spaceRamp.js
@@ -1,0 +1,38 @@
+// Shared easing for the "space mode" transition every background theme
+// component uses: each one calls this once per frame from its own draw()
+// loop, feeding the result to its shader as uSpaceT. Smoothstep-ramps
+// between 0/1 over RAMP_MS whenever the target flips, rather than popping
+// instantly, matching the codebase's existing taste for continuous blends
+// (the palette mix, the sun-cycle bob) — except under reduced motion, where
+// it snaps straight to the target, matching how the rest of each scene
+// already freezes rather than animates for that preference.
+const RAMP_MS = 850;
+
+export function createSpaceRamp(initialOn) {
+  let current = initialOn ? 1 : 0;
+  let from = current;
+  let target = current;
+  let changedAt = 0; // 0 means "already settled" — no ramp in progress
+  let last = initialOn;
+  const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+  return function update(targetOn) {
+    if (targetOn !== last) {
+      last = targetOn;
+      target = targetOn ? 1 : 0;
+      if (reduceMotion.matches) {
+        current = target;
+        changedAt = 0;
+      } else {
+        from = current;
+        changedAt = performance.now();
+      }
+    }
+    if (changedAt === 0) return current;
+    const t = Math.min((performance.now() - changedAt) / RAMP_MS, 1);
+    const eased = t * t * (3 - 2 * t);
+    current = from + (target - from) * eased;
+    if (t >= 1) changedAt = 0; // settled; stop recomputing a finished ramp
+    return current;
+  };
+}

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -4,26 +4,3 @@ body,
   height: 100%;
   margin: 0;
 }
-
-// react-tooltip ships its own base styles; these restyle it to match the
-// site, replacing the look the old v-tooltip stylesheet provided.
-// The class is doubled to out-specify react-tooltip's own single-class rules,
-// which would otherwise win on source order.
-//
-// A flat dark chip, not frosted glass — backdrop-filter has nothing stable
-// to read as "glass" on something this small that appears and vanishes
-// within a second.
-.app-tooltip.app-tooltip {
-  background-color: rgba(20, 20, 20, 0.92);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  color: #fff;
-  border-radius: 15px;
-  padding: 5px 10px 4px;
-  font-family: 'Lato', sans-serif;
-  opacity: 1;
-  z-index: 10000;
-}
-
-.app-tooltip-arrow {
-  display: none;
-}


### PR DESCRIPTION
Follow-through on PR #13's theme registry, which was explicitly built so more procedural WebGL backgrounds could be added later without touching `App.jsx`.

## Four new themes, spread across color and technique

Alongside the existing Sunset Ridge:

- **Dune Sea** — bright, pale midday sky over rounded sand dunes, reusing the same layered-silhouette technique as the sunset ridges but reparameterized (softer fold, color-only wind-ripple texture, heat shimmer near the horizon).
- **Polar Aurora** — a starfield and domain-warped, flowing aurora ribbons over a deep navy/violet night sky, with an icy ridge-band horizon.
- **Rainforest Canopy** — a fully bespoke composition: layered, thresholded 2D noise "canopy blob" masses (depth via color/alpha, not a height silhouette), a scrolling mist band, and light shafts through the gaps.
- **Open Ocean** — the layered-silhouette technique again, but with a periodic sine+noise wave-height field instead of the ridge fold, foam highlights at each crest, and a noise-broken sun-glitter streak on the water.

## Shared GLSL, now that there are 6 shaders instead of 2

The existing "duplicate the small noise helpers per shader" approach (seen in the résumé burn-close shader) made sense at 2 shaders total; going to 6+ turns that into a real maintenance liability, especially since more themes are planned. `src/shaders/common.glsl` now holds the shared hash/noise/fbm/ridge helpers plus two new ones (`starField`, `celestialBody`) the new themes need, concatenated as a plain text prefix onto each theme's own shader source before compiling — no preprocessor, no runtime abstraction. The existing sunset shader was migrated to use it too, verified with a before/after screenshot to confirm no visual regression.

## Space mode

A new taskbar toggle, independent of theme selection, that pushes whichever theme is currently active into a bespoke surreal variant — eased in/out over ~850ms rather than popping (snapping instantly under `prefers-reduced-motion`, matching how the rest of each scene already freezes for that preference). Each theme's escalation is different, not a generic overlay: the sunset gains a second, redder companion sun and a magenta zenith cast; the desert shifts to a rust Martian atmosphere with a ringed planet and two moons; the tundra's aurora intensifies with a third electric-magenta hue and a large cratered moon appears; the rainforest recolors to glowing bioluminescent cyan/violet with drifting spore motes and a striped gas giant visible through the canopy gaps; the ocean gets a second moon (with its own glitter streak) and glowing cyan foam.

## Taskbar UI

The old single-button "cycle to next theme" control is replaced with a proper dropdown (`role="menu"`, `menuitemradio` items, `aria-checked`) listing all 5 themes by name, reusing the same Escape-to-close/outside-click/focus-management idioms already established by the résumé modal rather than inventing new ones. The space-mode toggle is a separate one-shot button (`aria-pressed`) in the same taskbar row.

## Verification

Clean `npm run lint` / `format:check` / `build`. Driven behaviorally against a served production build: selected each of the 5 themes from the new dropdown and confirmed it renders with zero console/WebGL errors; toggled space mode on and off for every theme and confirmed each one's bespoke escalation actually appears; confirmed the sunset theme's visual output is unchanged after the `common.glsl` migration.

One open item, not a regression: the rainforest canopy currently reads more like an abstract soft-focus texture than a strongly legible "looking up through foliage" scene — functional and error-free, but a candidate for another visual pass if it doesn't land well in the preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NMtuu5EBhZVwHHdYMFa9dm)_