### PR TITLE
Crisper moons, real animal silhouettes, and a mobile Safari focus-ring fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@fortawesome/react-fontawesome": "^3.5.0",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
+        "react-icons": "^5.7.0",
         "react-router": "^8.3.0"
       },
       "devDependencies": {
@@ -5055,6 +5056,15 @@
       },
       "peerDependencies": {
         "react": "^19.2.8"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.7.0.tgz",
+      "integrity": "sha512-LBLy340Rzqy6+/yVhZKT3B/QpP1BZaesGqasf09HPOBzRarcDIFH0WwXlXQfE7q7ipxK4MSiC5DIBWURCny6fw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@fortawesome/react-fontawesome": "^3.5.0",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
+    "react-icons": "^5.7.0",
     "react-router": "^8.3.0"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,7 +34,27 @@ export default function App() {
   const resumeRef = useRef<HTMLElement>(null);
 
   useEffect(() => {
-    if (open) resumeRef.current?.focus();
+    if (!open) return undefined;
+    const el = resumeRef.current;
+    if (!el) return undefined;
+    // Focus needs to land here so keyboard/AT users get the newly-opened
+    // content, but this specific call is scripted focus triggered from the
+    // Résumé button's click handler, not a real keyboard interaction with
+    // this element — Chromium's :focus-visible heuristic recognizes that
+    // and stays quiet, but Safari's doesn't, so this alone was enough to
+    // flash the accent outline around the whole panel on iOS. Suppress the
+    // ring only for this one programmatic focus; it's cleared on the
+    // panel's own next focus-related event, so a real subsequent keyboard
+    // focus (tabbing away and back) still rings normally.
+    el.dataset.justOpened = 'true';
+    el.focus();
+    const clearFlag = () => delete el.dataset.justOpened;
+    el.addEventListener('focus', clearFlag, { once: true });
+    el.addEventListener('blur', clearFlag, { once: true });
+    return () => {
+      el.removeEventListener('focus', clearFlag);
+      el.removeEventListener('blur', clearFlag);
+    };
   }, [open]);
 
   // Starts the burn rather than closing immediately. All four dismiss paths

--- a/src/components/Creature.module.scss
+++ b/src/components/Creature.module.scss
@@ -1,0 +1,100 @@
+// Normal and Alien each get their own independently positioned/animated
+// track (see Creature.tsx's own comment for why), sized and placed via
+// inline style. `left`/`right` drive horizontal drift here specifically so
+// the gait animation below is free to animate `transform` on its own nested
+// element without the two ever fighting over the same property.
+.track {
+  position: absolute;
+  left: -18%;
+  pointer-events: none;
+  animation-name: driftRight;
+  animation-timing-function: linear;
+  animation-iteration-count: infinite;
+  transition: opacity 0.85s ease;
+}
+
+.reverse {
+  left: auto;
+  right: -18%;
+  animation-name: driftLeft;
+}
+
+@keyframes driftRight {
+  from {
+    left: -18%;
+  }
+  to {
+    left: 118%;
+  }
+}
+
+@keyframes driftLeft {
+  from {
+    right: -18%;
+  }
+  to {
+    right: 118%;
+  }
+}
+
+.icon {
+  width: 100%;
+  height: 100%;
+}
+
+.flap {
+  animation: flap 0.7s ease-in-out infinite;
+}
+
+.bob {
+  animation: bob 1.6s ease-in-out infinite;
+}
+
+.undulate {
+  animation: undulate 2.4s ease-in-out infinite;
+}
+
+@keyframes flap {
+  0%,
+  100% {
+    transform: scaleY(1) rotate(0deg);
+  }
+
+  50% {
+    transform: scaleY(0.82) rotate(-4deg);
+  }
+}
+
+@keyframes bob {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+
+  50% {
+    transform: translateY(-8%);
+  }
+}
+
+@keyframes undulate {
+  0%,
+  100% {
+    transform: rotate(-5deg);
+  }
+
+  50% {
+    transform: rotate(5deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .track {
+    animation: none;
+  }
+
+  .flap,
+  .bob,
+  .undulate {
+    animation: none;
+  }
+}

--- a/src/components/Creature.tsx
+++ b/src/components/Creature.tsx
@@ -1,0 +1,117 @@
+import { useMemo } from 'react';
+import type { IconType } from 'react-icons';
+import { getSceneSeed } from '../seed';
+import styles from './Creature.module.scss';
+
+export type CreatureMotion = 'flap' | 'bob' | 'undulate';
+
+export interface CreatureProps {
+  Normal: IconType;
+  Alien: IconType;
+  normalColor: string;
+  alienColor: string;
+  spaceMode: boolean;
+  size: number;
+  top: string;
+  // Defaults to `top` — most pairs occupy the same band, but a few (e.g. a
+  // bear walking the ice horizon cross-fading to a manta gliding through the
+  // aurora well above it) need the alien variant somewhere else entirely.
+  alienTop?: string;
+  duration: number;
+  motion: CreatureMotion;
+  // Defaults to `motion` — most pairs share a gait, but a few (e.g. a
+  // walking camel cross-fading to an undulating sandworm) need their own.
+  alienMotion?: CreatureMotion;
+  reverse?: boolean;
+  mirrored?: boolean;
+  glow?: boolean;
+}
+
+// A small vector silhouette (from react-icons' game-icons collection —
+// professionally drawn and immediately recognizable, unlike a hand-rolled
+// shader silhouette) drifting across its theme, cross-fading to an alien
+// counterpart in space mode exactly like every other space-mode element in
+// these scenes. Positioned as a plain DOM overlay above the WebGL canvas
+// rather than drawn inside the shader — there's no way to sample the
+// shader's own terrain-height function from here, so ground-walking
+// creatures sit at a fixed height near the horizon rather than tracking the
+// exact procedural ridge silhouette underneath them.
+//
+// Normal and Alien each get their own independent, fully-positioned track
+// rather than sharing one parent — a nested "position within a position"
+// would need the alien variant's own `top` to resolve as a percentage of
+// its wrapper's height, but that wrapper's height collapses to 0 once its
+// own children are absolutely positioned. Two independent tracks sidestep
+// that entirely, and since both use the exact same animation-duration/delay,
+// they move in perfect horizontal lockstep — it still reads as one creature
+// cross-fading in place, not two drifting independently.
+export default function Creature({
+  Normal,
+  Alien,
+  normalColor,
+  alienColor,
+  spaceMode,
+  size,
+  top,
+  alienTop,
+  duration,
+  motion,
+  alienMotion,
+  reverse = false,
+  mirrored = false,
+  glow = false,
+}: CreatureProps) {
+  // A negative animation-delay starts the loop partway through instead of
+  // at its beginning, so creatures don't all sync to the same phase — the
+  // one stable per-session seed already used for the procedural scenes
+  // gives each creature its own offset without a fresh RNG call per render.
+  const delay = useMemo(() => -((getSceneSeed() * 37 + duration) % duration), [duration]);
+
+  const flipStyle = mirrored ? { transform: 'scaleX(-1)' } : undefined;
+  // A tight blur: at these icon sizes (~35-45px) anything wider reads as a
+  // soft blob rather than a silhouette with a glowing edge.
+  const alienFlipStyle = glow
+    ? { ...flipStyle, filter: `drop-shadow(0 0 3px ${alienColor})` }
+    : flipStyle;
+
+  const trackClass = `${styles.track} ${reverse ? styles.reverse : ''}`;
+  const animationDuration = `${duration}s`;
+  const animationDelay = `${delay}s`;
+
+  return (
+    <>
+      <div
+        className={trackClass}
+        aria-hidden="true"
+        style={{
+          top,
+          width: size,
+          height: size,
+          opacity: spaceMode ? 0 : 1,
+          animationDuration,
+          animationDelay,
+        }}
+      >
+        <div className={`${styles.icon} ${styles[motion]}`}>
+          <Normal size={size} color={normalColor} style={flipStyle} />
+        </div>
+      </div>
+      <div
+        className={trackClass}
+        aria-hidden="true"
+        style={{
+          top: alienTop ?? top,
+          width: size,
+          height: size,
+          opacity: spaceMode ? 1 : 0,
+          animationDuration,
+          animationDelay,
+        }}
+      >
+        <div className={`${styles.icon} ${styles[alienMotion ?? motion]}`}>
+          <Alien size={size} color={alienColor} style={alienFlipStyle} />
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/DesertBg.tsx
+++ b/src/components/DesertBg.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useRef } from 'react';
+import { GiCamel, GiSandSnake } from 'react-icons/gi';
 import vertSource from '../shaders/landscape.vert?raw';
 import commonSource from '../shaders/common.glsl?raw';
 import themeFragSource from '../shaders/desert.frag?raw';
 import { createSpaceRamp } from '../spaceRamp';
 import { getSceneSeed } from '../seed';
+import Creature from './Creature';
 import styles from './LandscapeBg.module.scss';
 import type { BackgroundThemeComponentProps } from '../backgrounds';
 
@@ -169,5 +171,22 @@ export default function DesertBg({ spaceMode = false }: BackgroundThemeComponent
     drawRef.current?.();
   }, [spaceMode]);
 
-  return <canvas ref={canvasRef} className={styles.canvas} aria-hidden="true" />;
+  return (
+    <>
+      <canvas ref={canvasRef} className={styles.canvas} aria-hidden="true" />
+      <Creature
+        Normal={GiCamel}
+        Alien={GiSandSnake}
+        normalColor="#3a2a18"
+        alienColor="#8dff4f"
+        spaceMode={spaceMode}
+        size={40}
+        top="66%"
+        duration={38}
+        motion="bob"
+        alienMotion="undulate"
+        glow
+      />
+    </>
+  );
 }

--- a/src/components/LandscapeBg.tsx
+++ b/src/components/LandscapeBg.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useRef } from 'react';
+import { GiHawkEmblem, GiWyvern } from 'react-icons/gi';
 import vertSource from '../shaders/landscape.vert?raw';
 import commonSource from '../shaders/common.glsl?raw';
 import themeFragSource from '../shaders/landscape.frag?raw';
 import { createSpaceRamp } from '../spaceRamp';
 import { getSceneSeed } from '../seed';
+import Creature from './Creature';
 import styles from './LandscapeBg.module.scss';
 import type { BackgroundThemeComponentProps } from '../backgrounds';
 
@@ -206,5 +208,21 @@ export default function LandscapeBg({ spaceMode = false }: BackgroundThemeCompon
     drawRef.current?.();
   }, [spaceMode]);
 
-  return <canvas ref={canvasRef} className={styles.canvas} aria-hidden="true" />;
+  return (
+    <>
+      <canvas ref={canvasRef} className={styles.canvas} aria-hidden="true" />
+      <Creature
+        Normal={GiHawkEmblem}
+        Alien={GiWyvern}
+        normalColor="#2b1b12"
+        alienColor="#5fe3ff"
+        spaceMode={spaceMode}
+        size={44}
+        top="26%"
+        duration={34}
+        motion="flap"
+        glow
+      />
+    </>
+  );
 }

--- a/src/components/OceanBg.tsx
+++ b/src/components/OceanBg.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useRef } from 'react';
+import { GiSchoolOfFish, GiSquid, GiSpermWhale, GiJellyfish } from 'react-icons/gi';
 import vertSource from '../shaders/landscape.vert?raw';
 import commonSource from '../shaders/common.glsl?raw';
 import themeFragSource from '../shaders/ocean.frag?raw';
 import { createSpaceRamp } from '../spaceRamp';
 import { getSceneSeed } from '../seed';
+import Creature from './Creature';
 import styles from './LandscapeBg.module.scss';
 import type { BackgroundThemeComponentProps } from '../backgrounds';
 
@@ -169,5 +171,35 @@ export default function OceanBg({ spaceMode = false }: BackgroundThemeComponentP
     drawRef.current?.();
   }, [spaceMode]);
 
-  return <canvas ref={canvasRef} className={styles.canvas} aria-hidden="true" />;
+  return (
+    <>
+      <canvas ref={canvasRef} className={styles.canvas} aria-hidden="true" />
+      <Creature
+        Normal={GiSchoolOfFish}
+        Alien={GiSquid}
+        normalColor="#7fa8b8"
+        alienColor="#73f2e6"
+        spaceMode={spaceMode}
+        size={34}
+        top="58%"
+        duration={30}
+        motion="undulate"
+        glow
+      />
+      <Creature
+        Normal={GiSpermWhale}
+        Alien={GiJellyfish}
+        normalColor="#3d5a68"
+        alienColor="#a888ff"
+        spaceMode={spaceMode}
+        size={46}
+        top="66%"
+        duration={44}
+        motion="bob"
+        alienMotion="undulate"
+        reverse
+        glow
+      />
+    </>
+  );
 }

--- a/src/components/RainforestBg.tsx
+++ b/src/components/RainforestBg.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useRef } from 'react';
+import { GiPeaceDove, GiButterfly } from 'react-icons/gi';
 import vertSource from '../shaders/landscape.vert?raw';
 import commonSource from '../shaders/common.glsl?raw';
 import themeFragSource from '../shaders/rainforest.frag?raw';
 import { createSpaceRamp } from '../spaceRamp';
 import { getSceneSeed } from '../seed';
+import Creature from './Creature';
 import styles from './LandscapeBg.module.scss';
 import type { BackgroundThemeComponentProps } from '../backgrounds';
 
@@ -169,5 +171,21 @@ export default function RainforestBg({ spaceMode = false }: BackgroundThemeCompo
     drawRef.current?.();
   }, [spaceMode]);
 
-  return <canvas ref={canvasRef} className={styles.canvas} aria-hidden="true" />;
+  return (
+    <>
+      <canvas ref={canvasRef} className={styles.canvas} aria-hidden="true" />
+      <Creature
+        Normal={GiPeaceDove}
+        Alien={GiButterfly}
+        normalColor="#e0451b"
+        alienColor="#d9a8ff"
+        spaceMode={spaceMode}
+        size={40}
+        top="38%"
+        duration={32}
+        motion="flap"
+        glow
+      />
+    </>
+  );
 }

--- a/src/components/Resume.module.scss
+++ b/src/components/Resume.module.scss
@@ -39,6 +39,15 @@ $sans:
     outline: 2px solid $accent;
     outline-offset: -3px;
   }
+
+  // Suppresses the ring only for App.tsx's initial focus-on-open call —
+  // see its own comment for why that scripted focus needs this on some
+  // browsers but not others. Doubled pseudo-class/attribute selector for
+  // specificity, so this reliably wins over the plain rule above
+  // regardless of source order.
+  &[data-just-opened]:focus-visible {
+    outline: none;
+  }
 }
 
 // Full-height wrapper so the margin rule and grain span the whole document
@@ -58,20 +67,21 @@ $sans:
   // A scored/embossed crease rather than a flat drawn line — a dark core
   // plus a light sliver on the trailing edge reads as pressed into the
   // paper and catching light, the way an actual ruled/cut sheet would.
+  // Two solid 1px strokes (core + a same-width, unblurred highlight offset
+  // beside it) rather than a gradient/blur across one sub-pixel-wide
+  // (1.5px) element: a horizontal gradient has no room to express its own
+  // transition within under 2px, and a blurred shadow adds unpredictable
+  // extra width — at real device pixel ratios that was rasterizing as one
+  // flat, oversaturated line instead of the intended subtle crease.
   &::before {
     content: '';
     position: absolute;
     top: 0;
     bottom: 0;
     left: var(--rule-x);
-    width: 1.5px;
-    background: linear-gradient(
-      to right,
-      rgba(214, 67, 31, 0.34) 0%,
-      rgba(214, 67, 31, 0.34) 55%,
-      rgba(255, 255, 255, 0.4) 100%
-    );
-    box-shadow: 1px 0 1px rgba(36, 31, 27, 0.06);
+    width: 1px;
+    background: rgba(214, 67, 31, 0.34);
+    box-shadow: 1px 0 0 rgba(255, 255, 255, 0.4);
   }
 
   &::after {

--- a/src/components/TundraBg.tsx
+++ b/src/components/TundraBg.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useRef } from 'react';
+import { GiPolarBear, GiMantaRay } from 'react-icons/gi';
 import vertSource from '../shaders/landscape.vert?raw';
 import commonSource from '../shaders/common.glsl?raw';
 import themeFragSource from '../shaders/tundra.frag?raw';
 import { createSpaceRamp } from '../spaceRamp';
 import { getSceneSeed } from '../seed';
+import Creature from './Creature';
 import styles from './LandscapeBg.module.scss';
 import type { BackgroundThemeComponentProps } from '../backgrounds';
 
@@ -169,5 +171,23 @@ export default function TundraBg({ spaceMode = false }: BackgroundThemeComponent
     drawRef.current?.();
   }, [spaceMode]);
 
-  return <canvas ref={canvasRef} className={styles.canvas} aria-hidden="true" />;
+  return (
+    <>
+      <canvas ref={canvasRef} className={styles.canvas} aria-hidden="true" />
+      <Creature
+        Normal={GiPolarBear}
+        Alien={GiMantaRay}
+        normalColor="#b8bdc2"
+        alienColor="#7ea8ff"
+        spaceMode={spaceMode}
+        size={38}
+        top="74%"
+        alienTop="20%"
+        duration={40}
+        motion="bob"
+        alienMotion="undulate"
+        glow
+      />
+    </>
+  );
 }

--- a/src/shaders/common.glsl
+++ b/src/shaders/common.glsl
@@ -109,10 +109,16 @@ float litSphereShade(vec2 uv, vec2 center, float radius, vec2 lightDir2D, float 
 
 // A tight, solid edge — composed from two normal-order smoothsteps (rather
 // than one reversed-order one, which GLSL leaves spec-ambiguous) so the
-// transition is well-defined on every platform.
-float hardDiscMask(vec2 uv, vec2 center, float radius) {
+// transition is well-defined on every platform. Sized in actual screen
+// pixels (via `resolution`, every theme's own uResolution uniform) rather
+// than a fixed percentage of the body's own radius: a percentage-of-radius
+// band is several pixels wide on a small moon and reads as a soft blur, but
+// a fixed ~1.5px band anti-aliases the same everywhere regardless of how
+// small the body is or how dense the display.
+float hardDiscMask(vec2 uv, vec2 center, float radius, vec2 resolution) {
   float dist = length(uv - center);
-  return 1.0 - smoothstep(radius * 0.94, radius * 1.04, dist);
+  float pixel = 1.5 / resolution.y;
+  return 1.0 - smoothstep(radius - pixel, radius + pixel, dist);
 }
 
 // Distance from p to the segment a-b — the one shape every articulated

--- a/src/shaders/common.glsl
+++ b/src/shaders/common.glsl
@@ -120,19 +120,3 @@ float hardDiscMask(vec2 uv, vec2 center, float radius, vec2 resolution) {
   float pixel = 1.5 / resolution.y;
   return 1.0 - smoothstep(radius - pixel, radius + pixel, dist);
 }
-
-// Distance from p to the segment a-b — the one shape every articulated
-// creature (wings, legs, fins, tentacles, bodies) below is built from.
-float sdSegment(vec2 p, vec2 a, vec2 b) {
-  vec2 pa = p - a;
-  vec2 ba = b - a;
-  float h = clamp(dot(pa, ba) / dot(ba, ba), 0.0, 1.0);
-  return length(pa - ba * h);
-}
-
-// Soft-edged capsule mask (radius r around segment a-b): 1 inside, 0
-// outside.
-float capsuleMask(vec2 p, vec2 a, vec2 b, float r) {
-  float d = sdSegment(p, a, b) - r;
-  return 1.0 - smoothstep(0.0, r * 0.6, d);
-}

--- a/src/shaders/desert.frag
+++ b/src/shaders/desert.frag
@@ -169,7 +169,7 @@ void main() {
   // terminator (shaded toward the actual sun direction) with a crisp solid
   // edge, not celestialBody's soft self-luminous glow.
   float distToPlanet = length(planetUv);
-  float planetMask = hardDiscMask(auv, planetCenter, planetRadius);
+  float planetMask = hardDiscMask(auv, planetCenter, planetRadius, uResolution);
   float shade = litSphereShade(auv, planetCenter, planetRadius, sunDir, 0.10);
   vec3 planetBase = vec3(0.78, 0.58, 0.46);
   vec3 planetColor = planetBase * shade;
@@ -189,8 +189,8 @@ void main() {
   vec2 moonBCenter = vec2(0.88 * aspect, HORIZON + 0.14);
   float moonARadius = 0.016;
   float moonBRadius = 0.013;
-  float moonAMask = hardDiscMask(auv, moonACenter, moonARadius);
-  float moonBMask = hardDiscMask(auv, moonBCenter, moonBRadius);
+  float moonAMask = hardDiscMask(auv, moonACenter, moonARadius, uResolution);
+  float moonBMask = hardDiscMask(auv, moonBCenter, moonBRadius, uResolution);
   float moonAShade = litSphereShade(auv, moonACenter, moonARadius, normalize(sunCenter - moonACenter), 0.06);
   float moonBShade = litSphereShade(auv, moonBCenter, moonBRadius, normalize(sunCenter - moonBCenter), 0.06);
   vec3 moonColor = vec3(0.86, 0.84, 0.80);

--- a/src/shaders/desert.frag
+++ b/src/shaders/desert.frag
@@ -27,74 +27,6 @@ float duneFbm(float x) {
   return sum;
 }
 
-// Terrain height at world x, matching the near (foreground) dune layer's
-// own parameters from the layer loop below — so a walking creature's feet
-// land exactly on the ridge silhouette rather than floating or sinking.
-float terrainHeightAt(float x) {
-  float freq = 0.6;
-  float amp = 0.10;
-  float base = HORIZON - 0.16;
-  float speed = 0.0110;
-  float xf = x * freq + uTime * speed + uSeed * 9.0 + float(LAYERS - 1) * 19.3;
-  return base + duneFbm(xf) * amp;
-}
-
-// A camel walking the near dune ridge: hip/shoulder/neck/head plus two legs
-// alternating in antiphase for a walk cycle, feet planted on the terrain.
-float camelMask(vec2 auv, float aspect) {
-  float speed = 0.02;
-  float travel = fract(uTime * speed + uSeed * 5.0);
-  float xRange = aspect + 0.3;
-  float x = travel * xRange - 0.15;
-  float groundY = terrainHeightAt(x);
-
-  vec2 hip = vec2(x, groundY + 0.028);
-  vec2 shoulder = vec2(x - 0.026, groundY + 0.034);
-  vec2 neckTop = vec2(x - 0.040, groundY + 0.052);
-  vec2 head = vec2(x - 0.048, groundY + 0.048);
-
-  float body = capsuleMask(auv, hip, shoulder, 0.014);
-  float hump = capsuleMask(auv, shoulder, shoulder + vec2(-0.006, 0.010), 0.012);
-  float neck = capsuleMask(auv, shoulder, neckTop, 0.007);
-  float headM = capsuleMask(auv, neckTop, head, 0.006);
-
-  float legPhase = uTime * 3.0;
-  float legSwingBack = sin(legPhase) * 0.02;
-  float legSwingFront = -sin(legPhase) * 0.02;
-  vec2 legBackTop = hip - vec2(0.004, 0.006);
-  vec2 legBackBot = vec2(legBackTop.x + legSwingBack, groundY);
-  vec2 legFrontTop = shoulder - vec2(-0.004, 0.010);
-  vec2 legFrontBot = vec2(legFrontTop.x + legSwingFront, groundY);
-  float legBack = capsuleMask(auv, legBackTop, legBackBot, 0.005);
-  float legFront = capsuleMask(auv, legFrontTop, legFrontBot, 0.005);
-
-  return max(max(body, hump), max(neck, max(headM, max(legBack, legFront))));
-}
-
-// Space mode: a sandworm undulating along the dune horizon — a short
-// unrolled, tapering chain, each joint's angle offset by a sine wave down
-// the chain so it slithers rather than moving as a rigid line.
-float sandwormMask(vec2 auv, float aspect) {
-  float speed = 0.03;
-  float travel = fract(uTime * speed + uSeed * 13.0);
-  float xRange = aspect + 0.4;
-  float xStart = travel * xRange - 0.2;
-  float yBase = terrainHeightAt(xStart) + 0.01;
-
-  vec2 p0 = vec2(xStart, yBase);
-  float mask = 0.0;
-  for (int i = 0; i < 5; i++) {
-    float fi = float(i);
-    float angle = sin(uTime * 2.0 - fi * 1.0 + uSeed) * 0.35;
-    vec2 dir = vec2(cos(angle), sin(angle) * 0.6 + 0.15);
-    vec2 p1 = p0 + dir * 0.022;
-    float r = mix(0.012, 0.006, fi / 4.0);
-    mask = max(mask, capsuleMask(auv, p0, p1, r));
-    p0 = p1;
-  }
-  return mask;
-}
-
 void main() {
   vec2 uv = gl_FragCoord.xy / uResolution;
   float aspect = uResolution.x / uResolution.y;
@@ -240,16 +172,6 @@ void main() {
       col = ridge;
     }
   }
-
-  // Creatures: a camel walking the near ridge in normal mode, cross-fading
-  // to a sandworm undulating along the horizon in space mode.
-  float camelM = camelMask(auv, aspect);
-  vec3 camelColor = vec3(0.30, 0.19, 0.11);
-  col = mix(col, camelColor, camelM * (1.0 - uSpaceT));
-
-  float wormM = sandwormMask(auv, aspect);
-  vec3 wormColor = vec3(0.55, 0.20, 0.12);
-  col = mix(col, wormColor, wormM * uSpaceT);
 
   col += (hash21(gl_FragCoord.xy) - 0.5) / 255.0;
 

--- a/src/shaders/landscape.frag
+++ b/src/shaders/landscape.frag
@@ -1,7 +1,7 @@
 // Procedural sunset landscape: layered ridge silhouettes under a graded sky.
 // Everything is generated from uSeed, so every page load is a different
 // scene. Noise/fbm/ridge/celestial-body helpers live in common.glsl, which
-// LandscapeBg.jsx concatenates ahead of this source before compiling.
+// LandscapeBg.tsx concatenates ahead of this source before compiling.
 
 uniform vec2 uResolution;
 uniform float uTime;
@@ -56,52 +56,6 @@ Palette mixPalette(Palette a, Palette b, float t) {
     mix(a.sun, b.sun, t),
     mix(a.near, b.near, t)
   );
-}
-
-// --- creatures -----------------------------------------------------------
-
-// A hawk gliding across the sky: a body plus two wings that flap slowly
-// from the shoulder, looping across in its own lane.
-float hawkMask(vec2 auv, float aspect) {
-  float speed = 0.028;
-  float travel = fract(uTime * speed + uSeed * 6.0);
-  float xRange = aspect + 0.3;
-  float x = travel * xRange - 0.15;
-  float y = 0.72 + sin(uTime * 0.4 + uSeed * 2.0) * 0.03;
-  vec2 shoulder = vec2(x, y);
-  vec2 tail = shoulder - vec2(0.03, 0.0);
-  float body = capsuleMask(auv, shoulder, tail, 0.006);
-
-  float flap = sin(uTime * 2.2 + uSeed) * 0.5;
-  vec2 wingDirL = normalize(vec2(-0.8, 0.35 + flap));
-  vec2 wingDirR = normalize(vec2(0.8, 0.35 + flap));
-  vec2 wingL = shoulder + wingDirL * 0.028;
-  vec2 wingR = shoulder + wingDirR * 0.028;
-  float wl = capsuleMask(auv, shoulder, wingL, 0.005);
-  float wr = capsuleMask(auv, shoulder, wingR, 0.005);
-  return max(body, max(wl, wr));
-}
-
-// Space mode: a bioluminescent alien flyer on its own lane, wingtips
-// returned so the caller can add a soft glow trail at each one.
-float alienFlyerMask(vec2 auv, float aspect, out vec2 wingTipL, out vec2 wingTipR) {
-  float speed = 0.024;
-  float travel = fract(uTime * speed + uSeed * 9.0 + 0.5);
-  float xRange = aspect + 0.3;
-  float x = travel * xRange - 0.15;
-  float y = 0.68 + sin(uTime * 0.35 + uSeed * 3.0) * 0.04;
-  vec2 shoulder = vec2(x, y);
-  vec2 tail = shoulder - vec2(0.026, 0.0);
-  float body = capsuleMask(auv, shoulder, tail, 0.005);
-
-  float flap = sin(uTime * 1.6 + uSeed * 1.3) * 0.5;
-  vec2 dirL = normalize(vec2(-0.8, 0.3 + flap));
-  vec2 dirR = normalize(vec2(0.8, 0.3 + flap));
-  wingTipL = shoulder + dirL * 0.032;
-  wingTipR = shoulder + dirR * 0.032;
-  float wl = capsuleMask(auv, shoulder, wingTipL, 0.004);
-  float wr = capsuleMask(auv, shoulder, wingTipR, 0.004);
-  return max(body, max(wl, wr));
 }
 
 // --- scene -------------------------------------------------------------
@@ -174,22 +128,6 @@ void main() {
       col = ridge;
     }
   }
-
-  // Creatures: a gliding hawk in normal mode, cross-fading to a
-  // bioluminescent alien flyer (with a soft glowing wingtip trail) in space
-  // mode — the same "swap, don't stack" treatment as the binary-ember sun.
-  float hawkM = hawkMask(sunUv, aspect);
-  vec3 hawkColor = vec3(0.08, 0.05, 0.04);
-  col = mix(col, hawkColor, hawkM * (1.0 - uSpaceT));
-
-  vec2 wingTipL;
-  vec2 wingTipR;
-  float alienM = alienFlyerMask(sunUv, aspect, wingTipL, wingTipR);
-  vec3 alienColor = vec3(0.55, 0.85, 1.0);
-  float glowL = exp(-length(sunUv - wingTipL) * 140.0) * 0.4;
-  float glowR = exp(-length(sunUv - wingTipR) * 140.0) * 0.4;
-  col += alienColor * (glowL + glowR) * uSpaceT;
-  col = mix(col, alienColor, alienM * uSpaceT);
 
   // Ordered-ish dither: 8-bit output bands badly across a gradient this wide.
   col += (hash21(gl_FragCoord.xy) - 0.5) / 255.0;

--- a/src/shaders/ocean.frag
+++ b/src/shaders/ocean.frag
@@ -152,7 +152,7 @@ void main() {
   float moonX = fract(sunX + 0.4) * aspect;
   vec2 moonCenter = vec2(moonX, HORIZON + 0.30);
   float moonRadius = 0.028;
-  float moonMask = hardDiscMask(auv, moonCenter, moonRadius);
+  float moonMask = hardDiscMask(auv, moonCenter, moonRadius, uResolution);
   float moonShade = litSphereShade(auv, moonCenter, moonRadius, normalize(sunCenter - moonCenter), 0.08);
   vec3 moonColor = vec3(0.80, 0.85, 0.90);
   col = mix(col, moonColor * moonShade, moonMask * uSpaceT);

--- a/src/shaders/ocean.frag
+++ b/src/shaders/ocean.frag
@@ -39,76 +39,6 @@ float glitter(vec2 auv, float lightX, float horizonY) {
   return band * below * sparkle;
 }
 
-// A small fish: an elongated body plus a wagging tail fin, looping across
-// the surface in its own lane. `idx` (0, 1, 2...) offsets lane/phase/speed
-// so a handful read as a loose school rather than identical clones.
-float fishMask(vec2 auv, float aspect, float idx) {
-  float speed = 0.045 + idx * 0.012;
-  float travel = fract(uTime * speed + uSeed * (3.0 + idx * 4.0) + idx * 0.27);
-  float xRange = aspect + 0.3;
-  float x = travel * xRange - 0.15;
-  float laneY = HORIZON - 0.05 - idx * 0.02 + sin(uTime * 0.6 + idx) * 0.006;
-  float bodyLen = 0.026;
-  vec2 head = vec2(x, laneY);
-  vec2 mid = head - vec2(bodyLen * 0.5, 0.0);
-  float wag = sin(uTime * 7.0 + idx * 2.1) * 0.5;
-  vec2 tailDir = normalize(vec2(-1.0, wag));
-  vec2 tail = mid + tailDir * bodyLen * 0.6;
-  float body = capsuleMask(auv, head, mid, 0.007);
-  float tailFin = capsuleMask(auv, mid, tail, 0.004);
-  return max(body, tailFin);
-}
-
-// A whale surfacing and swimming across, slow body drift plus an
-// independently swishing tail fluke.
-float whaleMask(vec2 auv, float aspect) {
-  float speed = 0.018;
-  float travel = fract(uTime * speed + uSeed * 11.0);
-  float xRange = aspect + 0.4;
-  float x = travel * xRange - 0.2;
-  float y = HORIZON - 0.09 + sin(uTime * 0.25 + uSeed) * 0.01;
-  vec2 head = vec2(x, y);
-  vec2 mid = head - vec2(0.09, 0.0);
-  vec2 tailBase = mid - vec2(0.05, 0.0);
-  float swish = sin(uTime * 1.4 + uSeed * 3.0) * 0.4;
-  vec2 flukeDir = normalize(vec2(-1.0, swish));
-  vec2 flukeTip = tailBase + flukeDir * 0.05;
-  float body = capsuleMask(auv, head, mid, 0.028);
-  float taper = capsuleMask(auv, mid, tailBase, 0.014);
-  float fluke = capsuleMask(auv, tailBase, flukeTip, 0.010);
-  return max(max(body, taper), fluke);
-}
-
-// Space mode: a bioluminescent alien jellyfish/squid drifting across, with
-// trailing tentacles that each undulate independently — a short unrolled
-// chain per tentacle, each joint's angle offset by a sine wave staggered by
-// both its position down the chain and which tentacle it belongs to.
-float squidMask(vec2 auv, float aspect) {
-  float speed = 0.02;
-  float travel = fract(uTime * speed + uSeed * 17.0);
-  float xRange = aspect + 0.3;
-  float x = travel * xRange - 0.15;
-  float y = HORIZON - 0.12 + sin(uTime * 0.3 + uSeed * 2.0) * 0.02;
-  vec2 bellCenter = vec2(x, y);
-  float bellRadius = 0.03;
-  float bell = 1.0 - smoothstep(bellRadius * 0.9, bellRadius * 1.1, length(auv - bellCenter));
-
-  float tentacles = 0.0;
-  for (int t = 0; t < 4; t++) {
-    float ft = float(t);
-    vec2 p0 = bellCenter + vec2((ft - 1.5) * 0.012, -bellRadius * 0.6);
-    for (int s = 0; s < 3; s++) {
-      float fs = float(s);
-      float angle = -1.4 + sin(uTime * 2.2 - fs * 1.1 - ft * 0.7 + uSeed) * 0.5;
-      vec2 dir = vec2(sin(angle), -cos(angle));
-      vec2 p1 = p0 + dir * 0.018;
-      tentacles = max(tentacles, capsuleMask(auv, p0, p1, 0.004));
-      p0 = p1;
-    }
-  }
-  return max(bell, tentacles);
-}
-
 void main() {
   vec2 uv = gl_FragCoord.xy / uResolution;
   float aspect = uResolution.x / uResolution.y;
@@ -177,23 +107,6 @@ void main() {
       col = water;
     }
   }
-
-  // Creatures: a small fish school and a surfacing whale in normal mode,
-  // cross-fading to a bioluminescent alien squid in space mode — the same
-  // "swap, don't stack" treatment as every other space-mode element.
-  vec3 fishColor = vec3(0.05, 0.09, 0.14);
-  for (int i = 0; i < 3; i++) {
-    float m = fishMask(auv, aspect, float(i));
-    col = mix(col, fishColor, m * (1.0 - uSpaceT));
-  }
-  vec3 whaleColor = vec3(0.04, 0.07, 0.10);
-  float whaleM = whaleMask(auv, aspect);
-  col = mix(col, whaleColor, whaleM * (1.0 - uSpaceT));
-
-  vec3 squidColor = vec3(0.45, 0.95, 0.90);
-  float squidM = squidMask(auv, aspect);
-  col += squidColor * squidM * uSpaceT * 0.5;
-  col = mix(col, squidColor, squidM * uSpaceT);
 
   col += (hash21(gl_FragCoord.xy) - 0.5) / 255.0;
 

--- a/src/shaders/rainforest.frag
+++ b/src/shaders/rainforest.frag
@@ -15,47 +15,6 @@ uniform float uSpaceT; // 0 (normal) -> 1 (space mode), eased in JS
 
 const int LAYERS = 5;
 
-// A macaw flying between canopy gaps: fast colorful wing flap. Returns
-// (body, leftWing, rightWing) masks separately so each part can take its
-// own color in main() instead of one flat silhouette color.
-vec3 macawMask(vec2 auv, float aspect) {
-  float speed = 0.05;
-  float travel = fract(uTime * speed + uSeed * 4.0);
-  float xRange = aspect + 0.3;
-  float x = travel * xRange - 0.15;
-  float y = 0.55 + sin(uTime * 0.5 + uSeed * 2.0) * 0.08;
-  vec2 shoulder = vec2(x, y);
-  vec2 tail = shoulder - vec2(0.024, 0.0);
-  float body = capsuleMask(auv, shoulder, tail, 0.007);
-
-  float flap = sin(uTime * 5.0 + uSeed) * 0.6;
-  vec2 dirL = normalize(vec2(-0.9, 0.3 + flap));
-  vec2 dirR = normalize(vec2(0.9, 0.3 + flap));
-  vec2 wingL = shoulder + dirL * 0.022;
-  vec2 wingR = shoulder + dirR * 0.022;
-  float wl = capsuleMask(auv, shoulder, wingL, 0.006);
-  float wr = capsuleMask(auv, shoulder, wingR, 0.006);
-  return vec3(body, wl, wr);
-}
-
-// Space mode: a bioluminescent alien moth drifting slowly through the
-// glowing grove, wings flapping gently with a pulsing self-glow.
-float mothMask(vec2 auv, float aspect, out vec2 center) {
-  float speed = 0.015;
-  float travel = fract(uTime * speed + uSeed * 6.0 + 0.3);
-  float xRange = aspect + 0.3;
-  float x = travel * xRange - 0.15;
-  float y = 0.5 + sin(uTime * 0.25 + uSeed * 3.0) * 0.1;
-  center = vec2(x, y);
-  float flap = sin(uTime * 3.0 + uSeed) * 0.4;
-  vec2 dirL = normalize(vec2(-0.7, 0.4 + flap));
-  vec2 dirR = normalize(vec2(0.7, 0.4 + flap));
-  float wl = capsuleMask(auv, center, center + dirL * 0.018, 0.008);
-  float wr = capsuleMask(auv, center, center + dirR * 0.018, 0.008);
-  float body = capsuleMask(auv, center, center - vec2(0.0, 0.012), 0.004);
-  return max(body, max(wl, wr));
-}
-
 void main() {
   vec2 uv = gl_FragCoord.xy / uResolution;
   float aspect = uResolution.x / uResolution.y;
@@ -115,23 +74,6 @@ void main() {
   // Space mode: upward-drifting bioluminescent spore motes.
   float motes = starField(auv * 3.0 + vec2(0.0, -uTime * 0.05), uSeed + 70.0, 0.02);
   col += vec3(0.55, 1.0, 0.90) * motes * uSpaceT;
-
-  // Creatures: a colorful macaw flying between the canopy gaps in normal
-  // mode, cross-fading to a bioluminescent alien moth (with a pulsing
-  // self-glow) in space mode.
-  vec3 macaw = macawMask(auv, aspect);
-  float macawFade = 1.0 - uSpaceT;
-  col = mix(col, vec3(0.85, 0.10, 0.08), macaw.x * macawFade);
-  col = mix(col, vec3(0.10, 0.35, 0.85), macaw.y * macawFade);
-  col = mix(col, vec3(0.95, 0.75, 0.10), macaw.z * macawFade);
-
-  vec2 mothCenter;
-  float mothM = mothMask(auv, aspect, mothCenter);
-  vec3 mothColor = vec3(0.60, 0.95, 0.85);
-  float mothPulse = 0.5 + 0.5 * sin(uTime * 1.5 + uSeed);
-  float mothGlow = exp(-length(auv - mothCenter) * 60.0) * 0.4 * mothPulse;
-  col += mothColor * mothGlow * uSpaceT;
-  col = mix(col, mothColor, mothM * uSpaceT);
 
   col += (hash21(gl_FragCoord.xy) - 0.5) / 255.0;
 

--- a/src/shaders/tundra.frag
+++ b/src/shaders/tundra.frag
@@ -22,68 +22,6 @@ float auroraField(vec2 p, float t) {
   return fbm2(p * 1.3 + warp * 1.6 + vec2(t * 0.035, 0.0));
 }
 
-// Terrain height at world x, matching the near (foreground) ice layer's own
-// parameters from the layer loop below — so a walking creature's feet land
-// exactly on the ridge silhouette.
-float terrainHeightAt(float x) {
-  float freq = 0.8;
-  float amp = 0.09;
-  float base = HORIZON - 0.14;
-  float speed = 0.014;
-  float xf = x * freq + uTime * speed + uSeed * 11.0 + float(LAYERS - 1) * 23.1;
-  return base + ridgeFbm(xf) * amp;
-}
-
-// A polar bear walking the ice horizon: body/head plus two legs alternating
-// in antiphase for a walk cycle, feet planted on the terrain.
-float bearMask(vec2 auv, float aspect) {
-  float speed = 0.018;
-  float travel = fract(uTime * speed + uSeed * 4.0);
-  float xRange = aspect + 0.3;
-  float x = travel * xRange - 0.15;
-  float groundY = terrainHeightAt(x);
-
-  vec2 hip = vec2(x, groundY + 0.022);
-  vec2 shoulder = vec2(x - 0.034, groundY + 0.024);
-  vec2 head = vec2(x - 0.048, groundY + 0.030);
-
-  float body = capsuleMask(auv, hip, shoulder, 0.015);
-  float headM = capsuleMask(auv, shoulder, head, 0.010);
-
-  float legPhase = uTime * 2.6;
-  float legSwingBack = sin(legPhase) * 0.018;
-  float legSwingFront = -sin(legPhase) * 0.018;
-  vec2 legBackTop = hip - vec2(0.002, 0.004);
-  vec2 legBackBot = vec2(legBackTop.x + legSwingBack, groundY);
-  vec2 legFrontTop = shoulder - vec2(-0.002, 0.006);
-  vec2 legFrontBot = vec2(legFrontTop.x + legSwingFront, groundY);
-  float legBack = capsuleMask(auv, legBackTop, legBackBot, 0.006);
-  float legFront = capsuleMask(auv, legFrontTop, legFrontBot, 0.006);
-
-  return max(body, max(headM, max(legBack, legFront)));
-}
-
-// Space mode: an alien "sky manta" gliding through the aurora band — a
-// body plus two long wings that undulate rather than flap, wingtips
-// returned so the caller can add a soft glow.
-float mantaMask(vec2 auv, float aspect, out vec2 wingTipL, out vec2 wingTipR) {
-  float speed = 0.02;
-  float travel = fract(uTime * speed + uSeed * 8.0);
-  float xRange = aspect + 0.4;
-  float x = travel * xRange - 0.2;
-  float y = HORIZON + 0.35 + sin(uTime * 0.2 + uSeed * 2.0) * 0.05;
-  vec2 center = vec2(x, y);
-  float undulate = sin(uTime * 1.2 + uSeed) * 0.15;
-  vec2 dirL = normalize(vec2(-1.0, undulate));
-  vec2 dirR = normalize(vec2(1.0, -undulate));
-  wingTipL = center + dirL * 0.05;
-  wingTipR = center + dirR * 0.05;
-  float body = capsuleMask(auv, center, center - vec2(0.02, 0.0), 0.012);
-  float wl = capsuleMask(auv, center, wingTipL, 0.008);
-  float wr = capsuleMask(auv, center, wingTipR, 0.008);
-  return max(body, max(wl, wr));
-}
-
 void main() {
   vec2 uv = gl_FragCoord.xy / uResolution;
   float aspect = uResolution.x / uResolution.y;
@@ -147,22 +85,6 @@ void main() {
       col = ridge;
     }
   }
-
-  // Creatures: a polar bear walking the ice horizon in normal mode,
-  // cross-fading to an alien sky manta gliding through the aurora in space
-  // mode.
-  float bearM = bearMask(auv, aspect);
-  vec3 bearColor = vec3(0.72, 0.74, 0.76);
-  col = mix(col, bearColor, bearM * (1.0 - uSpaceT));
-
-  vec2 mantaWingL;
-  vec2 mantaWingR;
-  float mantaM = mantaMask(auv, aspect, mantaWingL, mantaWingR);
-  vec3 mantaColor = vec3(0.55, 0.65, 1.0);
-  float mantaGlowL = exp(-length(auv - mantaWingL) * 120.0) * 0.35;
-  float mantaGlowR = exp(-length(auv - mantaWingR) * 120.0) * 0.35;
-  col += mantaColor * (mantaGlowL + mantaGlowR) * uSpaceT;
-  col = mix(col, mantaColor, mantaM * uSpaceT);
 
   col += (hash21(gl_FragCoord.xy) - 0.5) / 255.0;
 

--- a/src/shaders/tundra.frag
+++ b/src/shaders/tundra.frag
@@ -123,7 +123,7 @@ void main() {
   vec2 moonCenter = vec2(0.72 * aspect, HORIZON + 0.10);
   float moonRadius = 0.075;
   vec2 moonLightDir = normalize(vec2(-0.5, 0.35));
-  float moonMask = hardDiscMask(auv, moonCenter, moonRadius);
+  float moonMask = hardDiscMask(auv, moonCenter, moonRadius, uResolution);
   float moonShade = litSphereShade(auv, moonCenter, moonRadius, moonLightDir, 0.12);
   float craters = fbm2((auv - moonCenter) * 40.0 + uSeed * 5.0);
   vec3 moonColor = mix(vec3(0.82, 0.80, 0.78), vec3(0.62, 0.60, 0.58), smoothstep(0.35, 0.7, craters));


### PR DESCRIPTION
## Summary
- Fixed moon/planet edge blur by sizing `hardDiscMask`'s anti-alias band in fixed screen pixels instead of a percentage of the body's own radius.
- Replaced every theme's hand-rolled shader creature with a shared `<Creature>` DOM overlay using `react-icons`' game-icons silhouettes, cross-fading to an alien counterpart in space mode (hawk/wyvern, camel/sandworm, polar bear/manta ray, dove/butterfly, fish-school+whale/squid+jellyfish).
- Fixed a stray orange outline flashing around the résumé panel on iOS Safari on open (a `:focus-visible` heuristic mismatch between Chromium and Safari for scripted focus), and replaced the notepad margin rule's sub-pixel gradient with two solid 1px strokes so it renders as a subtle crease rather than a solid line on real device pixel ratios.

## Test plan
- [x] `tsc --noEmit`, `eslint`, `prettier --check` all pass
- [x] `vitest run --coverage` passes, coverage above configured thresholds
- [x] `vite build` succeeds
- [x] Visually verified all 5 themes' creatures (normal + space mode, animation + reduced-motion) via Playwright screenshots against a production build
- [x] Verified the focus-ring fix's flag lifecycle (set on open, cleared on next focus/blur) and confirmed genuine keyboard refocus still shows the ring
- [ ] Real iOS Safari check (screenshot-driven fix; no physical device in this environment)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NMtuu5EBhZVwHHdYMFa9dm)_