### PR TITLE
Give creatures real walking legs, flapping wings, and swimming fins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@fortawesome/react-fontawesome": "^3.5.0",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
-        "react-icons": "^5.7.0",
         "react-router": "^8.3.0"
       },
       "devDependencies": {
@@ -5056,15 +5055,6 @@
       },
       "peerDependencies": {
         "react": "^19.2.8"
-      }
-    },
-    "node_modules/react-icons": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.7.0.tgz",
-      "integrity": "sha512-LBLy340Rzqy6+/yVhZKT3B/QpP1BZaesGqasf09HPOBzRarcDIFH0WwXlXQfE7q7ipxK4MSiC5DIBWURCny6fw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "@fortawesome/react-fontawesome": "^3.5.0",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
-    "react-icons": "^5.7.0",
     "react-router": "^8.3.0"
   },
   "devDependencies": {

--- a/src/components/Creature.module.scss
+++ b/src/components/Creature.module.scss
@@ -1,8 +1,9 @@
 // Normal and Alien each get their own independently positioned/animated
 // track (see Creature.tsx's own comment for why), sized and placed via
 // inline style. `left`/`right` drive horizontal drift here specifically so
-// the gait/wander animations below are free to animate `transform` on their
-// own nested elements without ever fighting the drift for the same property.
+// the wander animation below (and each creature's own internal gait rig)
+// is free to animate `transform` on its own element without ever fighting
+// the drift for the same property.
 .track {
   position: absolute;
   left: -18%;
@@ -39,7 +40,7 @@
 
 // A slow, independent altitude/current drift for airborne and aquatic
 // creatures — real flight and swimming paths wander a little on their own
-// timescale, layered underneath the much faster gait cycle rather than
+// timescale, layered underneath each creature's own gait rig rather than
 // moving in a dead-straight line. Grounded walkers skip this wrapper
 // entirely (see Creature.tsx) since they need to stay pinned to the terrain
 // line they're walking along.
@@ -62,110 +63,9 @@
   }
 }
 
-.icon {
-  width: 100%;
-  height: 100%;
-}
-
-.flap {
-  animation: flap 0.85s infinite;
-  animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-}
-
-.bob {
-  animation: walk 1.4s ease-in-out infinite;
-}
-
-.undulate {
-  animation: undulate 2.6s ease-in-out infinite;
-}
-
-// A wingbeat isn't a single symmetric pulse — the downstroke is the fast,
-// forceful part (generates lift/thrust), the upstroke recovers a little
-// past neutral, then it settles/glides before the next beat. Uneven
-// keyframe spacing plus the cubic-bezier above (rather than a plain
-// ease-in-out sine) is what actually reads as a flap instead of a wobble.
-@keyframes flap {
-  0% {
-    transform: scaleY(1) rotate(0deg);
-  }
-
-  18% {
-    transform: scaleY(0.7) rotate(-10deg);
-  }
-
-  38% {
-    transform: scaleY(1.08) rotate(4deg);
-  }
-
-  65% {
-    transform: scaleY(0.96) rotate(-2deg);
-  }
-
-  100% {
-    transform: scaleY(1) rotate(0deg);
-  }
-}
-
-// A real quadruped walk has two body-bob peaks per stride (weight
-// transfers between diagonal leg pairs) plus a slight side-to-side rock as
-// weight shifts — not one smooth vertical sine.
-@keyframes walk {
-  0% {
-    transform: translateY(0) rotate(0deg);
-  }
-
-  22% {
-    transform: translateY(-7%) rotate(-2.5deg);
-  }
-
-  50% {
-    transform: translateY(0) rotate(0deg);
-  }
-
-  72% {
-    transform: translateY(-7%) rotate(2.5deg);
-  }
-
-  100% {
-    transform: translateY(0) rotate(0deg);
-  }
-}
-
-// Serpentine/aquatic undulation is a traveling wave — the body passes
-// through several distinct bends per cycle, not just two extremes of a
-// single rock, and it doesn't move in one direction longer than another.
-@keyframes undulate {
-  0% {
-    transform: rotate(-7deg) translateX(-1%);
-  }
-
-  30% {
-    transform: rotate(4deg) translateX(1%);
-  }
-
-  55% {
-    transform: rotate(-3deg) translateX(-0.5%);
-  }
-
-  80% {
-    transform: rotate(5deg) translateX(0.5%);
-  }
-
-  100% {
-    transform: rotate(-7deg) translateX(-1%);
-  }
-}
-
 @media (prefers-reduced-motion: reduce) {
   .track,
   .wander {
-    animation: none;
-  }
-
-  .flap,
-  .bob,
-  .undulate {
     animation: none;
   }
 }

--- a/src/components/Creature.module.scss
+++ b/src/components/Creature.module.scss
@@ -1,8 +1,8 @@
 // Normal and Alien each get their own independently positioned/animated
 // track (see Creature.tsx's own comment for why), sized and placed via
 // inline style. `left`/`right` drive horizontal drift here specifically so
-// the gait animation below is free to animate `transform` on its own nested
-// element without the two ever fighting over the same property.
+// the gait/wander animations below are free to animate `transform` on their
+// own nested elements without ever fighting the drift for the same property.
 .track {
   position: absolute;
   left: -18%;
@@ -37,58 +37,129 @@
   }
 }
 
-.icon {
+// A slow, independent altitude/current drift for airborne and aquatic
+// creatures — real flight and swimming paths wander a little on their own
+// timescale, layered underneath the much faster gait cycle rather than
+// moving in a dead-straight line. Grounded walkers skip this wrapper
+// entirely (see Creature.tsx) since they need to stay pinned to the terrain
+// line they're walking along.
+.wander {
   width: 100%;
   height: 100%;
+  animation-name: wander;
+  animation-timing-function: ease-in-out;
+  animation-iteration-count: infinite;
 }
 
-.flap {
-  animation: flap 0.7s ease-in-out infinite;
-}
-
-.bob {
-  animation: bob 1.6s ease-in-out infinite;
-}
-
-.undulate {
-  animation: undulate 2.4s ease-in-out infinite;
-}
-
-@keyframes flap {
-  0%,
-  100% {
-    transform: scaleY(1) rotate(0deg);
-  }
-
-  50% {
-    transform: scaleY(0.82) rotate(-4deg);
-  }
-}
-
-@keyframes bob {
+@keyframes wander {
   0%,
   100% {
     transform: translateY(0);
   }
 
   50% {
-    transform: translateY(-8%);
+    transform: translateY(-6%);
   }
 }
 
-@keyframes undulate {
-  0%,
+.icon {
+  width: 100%;
+  height: 100%;
+}
+
+.flap {
+  animation: flap 0.85s infinite;
+  animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.bob {
+  animation: walk 1.4s ease-in-out infinite;
+}
+
+.undulate {
+  animation: undulate 2.6s ease-in-out infinite;
+}
+
+// A wingbeat isn't a single symmetric pulse — the downstroke is the fast,
+// forceful part (generates lift/thrust), the upstroke recovers a little
+// past neutral, then it settles/glides before the next beat. Uneven
+// keyframe spacing plus the cubic-bezier above (rather than a plain
+// ease-in-out sine) is what actually reads as a flap instead of a wobble.
+@keyframes flap {
+  0% {
+    transform: scaleY(1) rotate(0deg);
+  }
+
+  18% {
+    transform: scaleY(0.7) rotate(-10deg);
+  }
+
+  38% {
+    transform: scaleY(1.08) rotate(4deg);
+  }
+
+  65% {
+    transform: scaleY(0.96) rotate(-2deg);
+  }
+
   100% {
-    transform: rotate(-5deg);
+    transform: scaleY(1) rotate(0deg);
+  }
+}
+
+// A real quadruped walk has two body-bob peaks per stride (weight
+// transfers between diagonal leg pairs) plus a slight side-to-side rock as
+// weight shifts — not one smooth vertical sine.
+@keyframes walk {
+  0% {
+    transform: translateY(0) rotate(0deg);
+  }
+
+  22% {
+    transform: translateY(-7%) rotate(-2.5deg);
   }
 
   50% {
-    transform: rotate(5deg);
+    transform: translateY(0) rotate(0deg);
+  }
+
+  72% {
+    transform: translateY(-7%) rotate(2.5deg);
+  }
+
+  100% {
+    transform: translateY(0) rotate(0deg);
+  }
+}
+
+// Serpentine/aquatic undulation is a traveling wave — the body passes
+// through several distinct bends per cycle, not just two extremes of a
+// single rock, and it doesn't move in one direction longer than another.
+@keyframes undulate {
+  0% {
+    transform: rotate(-7deg) translateX(-1%);
+  }
+
+  30% {
+    transform: rotate(4deg) translateX(1%);
+  }
+
+  55% {
+    transform: rotate(-3deg) translateX(-0.5%);
+  }
+
+  80% {
+    transform: rotate(5deg) translateX(0.5%);
+  }
+
+  100% {
+    transform: rotate(-7deg) translateX(-1%);
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .track {
+  .track,
+  .wander {
     animation: none;
   }
 

--- a/src/components/Creature.tsx
+++ b/src/components/Creature.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, type CSSProperties } from 'react';
 import type { IconType } from 'react-icons';
 import { getSceneSeed } from '../seed';
 import styles from './Creature.module.scss';
@@ -22,6 +22,15 @@ export interface CreatureProps {
   // Defaults to `motion` — most pairs share a gait, but a few (e.g. a
   // walking camel cross-fading to an undulating sandworm) need their own.
   alienMotion?: CreatureMotion;
+  // Whether this variant drifts a little in altitude/current on its own,
+  // independent of its gait (see the `.wander` comment in the stylesheet).
+  // Defaults to true — most creatures are airborne or aquatic. Ground
+  // walkers (a camel, a bear) need this off, since they have to stay
+  // pinned to the terrain line they're walking along rather than floating.
+  wander?: boolean;
+  // Defaults to `wander` — needed when the two variants differ (a grounded
+  // bear cross-fading to a gliding manta).
+  alienWander?: boolean;
   reverse?: boolean;
   mirrored?: boolean;
   glow?: boolean;
@@ -37,14 +46,13 @@ export interface CreatureProps {
 // creatures sit at a fixed height near the horizon rather than tracking the
 // exact procedural ridge silhouette underneath them.
 //
-// Normal and Alien each get their own independent, fully-positioned track
-// rather than sharing one parent — a nested "position within a position"
-// would need the alien variant's own `top` to resolve as a percentage of
-// its wrapper's height, but that wrapper's height collapses to 0 once its
-// own children are absolutely positioned. Two independent tracks sidestep
-// that entirely, and since both use the exact same animation-duration/delay,
-// they move in perfect horizontal lockstep — it still reads as one creature
-// cross-fading in place, not two drifting independently.
+// Motion is layered across up to three independent elements so none of them
+// fight over the same CSS property: `.track` drives horizontal drift
+// (`left`/`right`, not `transform`); an optional `.wander` wrapper drifts
+// vertically on its own slow timescale for airborne/aquatic creatures; and
+// the innermost `.icon` plays the fast gait cycle (`transform`). Static
+// mirror/glow styling lives directly on the icon's own inline style, one
+// level deeper still.
 export default function Creature({
   Normal,
   Alien,
@@ -57,15 +65,25 @@ export default function Creature({
   duration,
   motion,
   alienMotion,
+  wander = true,
+  alienWander,
   reverse = false,
   mirrored = false,
   glow = false,
 }: CreatureProps) {
-  // A negative animation-delay starts the loop partway through instead of
-  // at its beginning, so creatures don't all sync to the same phase — the
-  // one stable per-session seed already used for the procedural scenes
-  // gives each creature its own offset without a fresh RNG call per render.
+  // Negative animation-delays start each loop partway through instead of at
+  // its beginning, so creatures (and their independent wander drift) don't
+  // all sync to the same phase — the one stable per-session seed already
+  // used for the procedural scenes gives each its own offset without a
+  // fresh RNG call per render. The wander delay/duration use different
+  // multipliers than the drift delay so the two motions stay decorrelated
+  // rather than lining up into one bigger, still-mechanical-looking cycle.
   const delay = useMemo(() => -((getSceneSeed() * 37 + duration) % duration), [duration]);
+  const wanderDuration = useMemo(() => 5 + ((getSceneSeed() * 71) % 3), []);
+  const wanderDelay = useMemo(
+    () => -((getSceneSeed() * 113 + wanderDuration) % wanderDuration),
+    [wanderDuration],
+  );
 
   const flipStyle = mirrored ? { transform: 'scaleX(-1)' } : undefined;
   // A tight blur: at these icon sizes (~35-45px) anything wider reads as a
@@ -77,6 +95,26 @@ export default function Creature({
   const trackClass = `${styles.track} ${reverse ? styles.reverse : ''}`;
   const animationDuration = `${duration}s`;
   const animationDelay = `${delay}s`;
+  const wanderStyle = {
+    animationDuration: `${wanderDuration}s`,
+    animationDelay: `${wanderDelay}s`,
+  };
+
+  const renderIcon = (
+    Icon: IconType,
+    color: string,
+    gait: CreatureMotion,
+    style: CSSProperties | undefined,
+  ) => (
+    <div className={`${styles.icon} ${styles[gait]}`}>
+      <Icon size={size} color={color} style={style} />
+    </div>
+  );
+
+  const normalGait = motion;
+  const alienGait = alienMotion ?? motion;
+  const normalWander = wander;
+  const alienWanderResolved = alienWander ?? wander;
 
   return (
     <>
@@ -92,9 +130,13 @@ export default function Creature({
           animationDelay,
         }}
       >
-        <div className={`${styles.icon} ${styles[motion]}`}>
-          <Normal size={size} color={normalColor} style={flipStyle} />
-        </div>
+        {normalWander ? (
+          <div className={styles.wander} style={wanderStyle}>
+            {renderIcon(Normal, normalColor, normalGait, flipStyle)}
+          </div>
+        ) : (
+          renderIcon(Normal, normalColor, normalGait, flipStyle)
+        )}
       </div>
       <div
         className={trackClass}
@@ -108,9 +150,13 @@ export default function Creature({
           animationDelay,
         }}
       >
-        <div className={`${styles.icon} ${styles[alienMotion ?? motion]}`}>
-          <Alien size={size} color={alienColor} style={alienFlipStyle} />
-        </div>
+        {alienWanderResolved ? (
+          <div className={styles.wander} style={wanderStyle}>
+            {renderIcon(Alien, alienColor, alienGait, alienFlipStyle)}
+          </div>
+        ) : (
+          renderIcon(Alien, alienColor, alienGait, alienFlipStyle)
+        )}
       </div>
     </>
   );

--- a/src/components/Creature.tsx
+++ b/src/components/Creature.tsx
@@ -1,13 +1,13 @@
-import { useMemo, type CSSProperties } from 'react';
-import type { IconType } from 'react-icons';
+import { useMemo, type ReactNode } from 'react';
 import { getSceneSeed } from '../seed';
 import styles from './Creature.module.scss';
+import type { CreatureSvgProps } from './creatures/types';
 
-export type CreatureMotion = 'flap' | 'bob' | 'undulate';
+type CreatureComponent = (props: CreatureSvgProps) => ReactNode;
 
 export interface CreatureProps {
-  Normal: IconType;
-  Alien: IconType;
+  Normal: CreatureComponent;
+  Alien: CreatureComponent;
   normalColor: string;
   alienColor: string;
   spaceMode: boolean;
@@ -18,10 +18,6 @@ export interface CreatureProps {
   // aurora well above it) need the alien variant somewhere else entirely.
   alienTop?: string;
   duration: number;
-  motion: CreatureMotion;
-  // Defaults to `motion` — most pairs share a gait, but a few (e.g. a
-  // walking camel cross-fading to an undulating sandworm) need their own.
-  alienMotion?: CreatureMotion;
   // Whether this variant drifts a little in altitude/current on its own,
   // independent of its gait (see the `.wander` comment in the stylesheet).
   // Defaults to true — most creatures are airborne or aquatic. Ground
@@ -36,9 +32,9 @@ export interface CreatureProps {
   glow?: boolean;
 }
 
-// A small vector silhouette (from react-icons' game-icons collection —
-// professionally drawn and immediately recognizable, unlike a hand-rolled
-// shader silhouette) drifting across its theme, cross-fading to an alien
+// A small rigged SVG creature (see ./creatures — a static body plus a
+// handful of separately-animated parts, each pivoting from its own hip/
+// shoulder/tail-base) drifting across its theme, cross-fading to an alien
 // counterpart in space mode exactly like every other space-mode element in
 // these scenes. Positioned as a plain DOM overlay above the WebGL canvas
 // rather than drawn inside the shader — there's no way to sample the
@@ -46,13 +42,13 @@ export interface CreatureProps {
 // creatures sit at a fixed height near the horizon rather than tracking the
 // exact procedural ridge silhouette underneath them.
 //
-// Motion is layered across up to three independent elements so none of them
-// fight over the same CSS property: `.track` drives horizontal drift
-// (`left`/`right`, not `transform`); an optional `.wander` wrapper drifts
-// vertically on its own slow timescale for airborne/aquatic creatures; and
-// the innermost `.icon` plays the fast gait cycle (`transform`). Static
-// mirror/glow styling lives directly on the icon's own inline style, one
-// level deeper still.
+// Only two motion layers live here: `.track` drives horizontal drift
+// (`left`/`right`, not `transform`), and an optional `.wander` wrapper
+// drifts vertically on its own slow timescale for airborne/aquatic
+// creatures. The actual gait (leg/wing/fin articulation) is internal to
+// each creature component now, not applied externally — a single flat icon
+// could only wobble as one rigid shape, but a multi-part rig needs each
+// part animating independently, which has to live inside the SVG itself.
 export default function Creature({
   Normal,
   Alien,
@@ -63,8 +59,6 @@ export default function Creature({
   top,
   alienTop,
   duration,
-  motion,
-  alienMotion,
   wander = true,
   alienWander,
   reverse = false,
@@ -100,19 +94,6 @@ export default function Creature({
     animationDelay: `${wanderDelay}s`,
   };
 
-  const renderIcon = (
-    Icon: IconType,
-    color: string,
-    gait: CreatureMotion,
-    style: CSSProperties | undefined,
-  ) => (
-    <div className={`${styles.icon} ${styles[gait]}`}>
-      <Icon size={size} color={color} style={style} />
-    </div>
-  );
-
-  const normalGait = motion;
-  const alienGait = alienMotion ?? motion;
   const normalWander = wander;
   const alienWanderResolved = alienWander ?? wander;
 
@@ -132,10 +113,10 @@ export default function Creature({
       >
         {normalWander ? (
           <div className={styles.wander} style={wanderStyle}>
-            {renderIcon(Normal, normalColor, normalGait, flipStyle)}
+            <Normal size={size} color={normalColor} style={flipStyle} />
           </div>
         ) : (
-          renderIcon(Normal, normalColor, normalGait, flipStyle)
+          <Normal size={size} color={normalColor} style={flipStyle} />
         )}
       </div>
       <div
@@ -152,10 +133,10 @@ export default function Creature({
       >
         {alienWanderResolved ? (
           <div className={styles.wander} style={wanderStyle}>
-            {renderIcon(Alien, alienColor, alienGait, alienFlipStyle)}
+            <Alien size={size} color={alienColor} style={alienFlipStyle} />
           </div>
         ) : (
-          renderIcon(Alien, alienColor, alienGait, alienFlipStyle)
+          <Alien size={size} color={alienColor} style={alienFlipStyle} />
         )}
       </div>
     </>

--- a/src/components/DesertBg.tsx
+++ b/src/components/DesertBg.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useRef } from 'react';
-import { GiCamel, GiSandSnake } from 'react-icons/gi';
 import vertSource from '../shaders/landscape.vert?raw';
 import commonSource from '../shaders/common.glsl?raw';
 import themeFragSource from '../shaders/desert.frag?raw';
 import { createSpaceRamp } from '../spaceRamp';
 import { getSceneSeed } from '../seed';
 import Creature from './Creature';
+import Camel from './creatures/Camel';
+import SandWorm from './creatures/SandWorm';
 import styles from './LandscapeBg.module.scss';
 import type { BackgroundThemeComponentProps } from '../backgrounds';
 
@@ -175,16 +176,14 @@ export default function DesertBg({ spaceMode = false }: BackgroundThemeComponent
     <>
       <canvas ref={canvasRef} className={styles.canvas} aria-hidden="true" />
       <Creature
-        Normal={GiCamel}
-        Alien={GiSandSnake}
+        Normal={Camel}
+        Alien={SandWorm}
         normalColor="#3a2a18"
         alienColor="#8dff4f"
         spaceMode={spaceMode}
         size={40}
         top="66%"
         duration={38}
-        motion="bob"
-        alienMotion="undulate"
         wander={false}
         glow
       />

--- a/src/components/DesertBg.tsx
+++ b/src/components/DesertBg.tsx
@@ -185,6 +185,7 @@ export default function DesertBg({ spaceMode = false }: BackgroundThemeComponent
         duration={38}
         motion="bob"
         alienMotion="undulate"
+        wander={false}
         glow
       />
     </>

--- a/src/components/LandscapeBg.tsx
+++ b/src/components/LandscapeBg.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useRef } from 'react';
-import { GiHawkEmblem, GiWyvern } from 'react-icons/gi';
 import vertSource from '../shaders/landscape.vert?raw';
 import commonSource from '../shaders/common.glsl?raw';
 import themeFragSource from '../shaders/landscape.frag?raw';
 import { createSpaceRamp } from '../spaceRamp';
 import { getSceneSeed } from '../seed';
 import Creature from './Creature';
+import Hawk from './creatures/Hawk';
+import Wyvern from './creatures/Wyvern';
 import styles from './LandscapeBg.module.scss';
 import type { BackgroundThemeComponentProps } from '../backgrounds';
 
@@ -212,15 +213,14 @@ export default function LandscapeBg({ spaceMode = false }: BackgroundThemeCompon
     <>
       <canvas ref={canvasRef} className={styles.canvas} aria-hidden="true" />
       <Creature
-        Normal={GiHawkEmblem}
-        Alien={GiWyvern}
+        Normal={Hawk}
+        Alien={Wyvern}
         normalColor="#2b1b12"
         alienColor="#5fe3ff"
         spaceMode={spaceMode}
         size={44}
         top="26%"
         duration={34}
-        motion="flap"
         glow
       />
     </>

--- a/src/components/OceanBg.tsx
+++ b/src/components/OceanBg.tsx
@@ -9,6 +9,7 @@ import FishSchool from './creatures/FishSchool';
 import Squid from './creatures/Squid';
 import Whale from './creatures/Whale';
 import Jellyfish from './creatures/Jellyfish';
+import WaveOverlay from './WaveOverlay';
 import styles from './LandscapeBg.module.scss';
 import type { BackgroundThemeComponentProps } from '../backgrounds';
 
@@ -200,6 +201,12 @@ export default function OceanBg({ spaceMode = false }: BackgroundThemeComponentP
         reverse
         glow
       />
+      {/* Foreground wave crests, drawn on top of the fish/whale so they
+          read as swimming beneath the surface texture rather than in
+          front of it — see WaveOverlay's own comment for why the shader's
+          own foam crests can't provide this on their own. */}
+      <WaveOverlay top="57%" />
+      <WaveOverlay top="65%" />
     </>
   );
 }

--- a/src/components/OceanBg.tsx
+++ b/src/components/OceanBg.tsx
@@ -1,11 +1,14 @@
 import { useEffect, useRef } from 'react';
-import { GiSchoolOfFish, GiSquid, GiSpermWhale, GiJellyfish } from 'react-icons/gi';
 import vertSource from '../shaders/landscape.vert?raw';
 import commonSource from '../shaders/common.glsl?raw';
 import themeFragSource from '../shaders/ocean.frag?raw';
 import { createSpaceRamp } from '../spaceRamp';
 import { getSceneSeed } from '../seed';
 import Creature from './Creature';
+import FishSchool from './creatures/FishSchool';
+import Squid from './creatures/Squid';
+import Whale from './creatures/Whale';
+import Jellyfish from './creatures/Jellyfish';
 import styles from './LandscapeBg.module.scss';
 import type { BackgroundThemeComponentProps } from '../backgrounds';
 
@@ -175,28 +178,25 @@ export default function OceanBg({ spaceMode = false }: BackgroundThemeComponentP
     <>
       <canvas ref={canvasRef} className={styles.canvas} aria-hidden="true" />
       <Creature
-        Normal={GiSchoolOfFish}
-        Alien={GiSquid}
+        Normal={FishSchool}
+        Alien={Squid}
         normalColor="#7fa8b8"
         alienColor="#73f2e6"
         spaceMode={spaceMode}
         size={34}
         top="58%"
         duration={30}
-        motion="undulate"
         glow
       />
       <Creature
-        Normal={GiSpermWhale}
-        Alien={GiJellyfish}
+        Normal={Whale}
+        Alien={Jellyfish}
         normalColor="#3d5a68"
         alienColor="#a888ff"
         spaceMode={spaceMode}
         size={46}
         top="66%"
         duration={44}
-        motion="bob"
-        alienMotion="undulate"
         reverse
         glow
       />

--- a/src/components/RainforestBg.tsx
+++ b/src/components/RainforestBg.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useRef } from 'react';
-import { GiPeaceDove, GiButterfly } from 'react-icons/gi';
 import vertSource from '../shaders/landscape.vert?raw';
 import commonSource from '../shaders/common.glsl?raw';
 import themeFragSource from '../shaders/rainforest.frag?raw';
 import { createSpaceRamp } from '../spaceRamp';
 import { getSceneSeed } from '../seed';
 import Creature from './Creature';
+import Dove from './creatures/Dove';
+import Butterfly from './creatures/Butterfly';
 import styles from './LandscapeBg.module.scss';
 import type { BackgroundThemeComponentProps } from '../backgrounds';
 
@@ -175,15 +176,14 @@ export default function RainforestBg({ spaceMode = false }: BackgroundThemeCompo
     <>
       <canvas ref={canvasRef} className={styles.canvas} aria-hidden="true" />
       <Creature
-        Normal={GiPeaceDove}
-        Alien={GiButterfly}
+        Normal={Dove}
+        Alien={Butterfly}
         normalColor="#e0451b"
         alienColor="#d9a8ff"
         spaceMode={spaceMode}
         size={40}
         top="38%"
         duration={32}
-        motion="flap"
         glow
       />
     </>

--- a/src/components/TundraBg.tsx
+++ b/src/components/TundraBg.tsx
@@ -186,6 +186,8 @@ export default function TundraBg({ spaceMode = false }: BackgroundThemeComponent
         duration={40}
         motion="bob"
         alienMotion="undulate"
+        wander={false}
+        alienWander
         glow
       />
     </>

--- a/src/components/TundraBg.tsx
+++ b/src/components/TundraBg.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useRef } from 'react';
-import { GiPolarBear, GiMantaRay } from 'react-icons/gi';
 import vertSource from '../shaders/landscape.vert?raw';
 import commonSource from '../shaders/common.glsl?raw';
 import themeFragSource from '../shaders/tundra.frag?raw';
 import { createSpaceRamp } from '../spaceRamp';
 import { getSceneSeed } from '../seed';
 import Creature from './Creature';
+import PolarBear from './creatures/PolarBear';
+import MantaRay from './creatures/MantaRay';
 import styles from './LandscapeBg.module.scss';
 import type { BackgroundThemeComponentProps } from '../backgrounds';
 
@@ -175,8 +176,8 @@ export default function TundraBg({ spaceMode = false }: BackgroundThemeComponent
     <>
       <canvas ref={canvasRef} className={styles.canvas} aria-hidden="true" />
       <Creature
-        Normal={GiPolarBear}
-        Alien={GiMantaRay}
+        Normal={PolarBear}
+        Alien={MantaRay}
         normalColor="#b8bdc2"
         alienColor="#7ea8ff"
         spaceMode={spaceMode}
@@ -184,8 +185,6 @@ export default function TundraBg({ spaceMode = false }: BackgroundThemeComponent
         top="74%"
         alienTop="20%"
         duration={40}
-        motion="bob"
-        alienMotion="undulate"
         wander={false}
         alienWander
         glow

--- a/src/components/WaveOverlay.module.scss
+++ b/src/components/WaveOverlay.module.scss
@@ -1,0 +1,33 @@
+// A thin foreground wave crest, drawn as a plain DOM overlay so it always
+// renders in front of any creature at the same height — the ocean shader's
+// own foam crests are baked into the canvas below every DOM element, so a
+// fish swimming at that height was always drawn on top of the crest line
+// it should be passing behind. This doesn't try to track the shader's
+// procedural wave shape exactly (that would mean duplicating its noise
+// function in JS/CSS) — a gentle drifting sine reads as "a ripple in front"
+// well enough for a decorative background.
+.wave {
+  position: absolute;
+  left: -10%;
+  width: 120%;
+  height: 22px;
+  pointer-events: none;
+  animation: drift 14s ease-in-out infinite;
+}
+
+@keyframes drift {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+
+  50% {
+    transform: translateX(2%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .wave {
+    animation: none;
+  }
+}

--- a/src/components/WaveOverlay.tsx
+++ b/src/components/WaveOverlay.tsx
@@ -1,0 +1,27 @@
+import styles from './WaveOverlay.module.scss';
+
+export interface WaveOverlayProps {
+  top: string;
+  color?: string;
+}
+
+// A thin, gently drifting wave-crest line — see the stylesheet's own
+// comment for why this needs to exist as a separate DOM layer at all.
+export default function WaveOverlay({ top, color = 'rgba(255,255,255,0.4)' }: WaveOverlayProps) {
+  return (
+    <svg
+      className={styles.wave}
+      style={{ top }}
+      aria-hidden="true"
+      viewBox="0 0 400 22"
+      preserveAspectRatio="none"
+    >
+      <path
+        d="M -20,11 C 20,3 60,19 100,11 C 140,3 180,19 220,11 C 260,3 300,19 340,11 C 380,3 420,19 460,11"
+        fill="none"
+        stroke={color}
+        strokeWidth="2"
+      />
+    </svg>
+  );
+}

--- a/src/components/creatures/Butterfly.tsx
+++ b/src/components/creatures/Butterfly.tsx
@@ -1,0 +1,27 @@
+import rig from './rig.module.scss';
+import type { CreatureSvgProps } from './types';
+
+// A butterfly: each side's fore- and hind-wing move together as one unit,
+// flapping in sync with the opposite side via the same wing/wingMirror
+// pair used for birds.
+export default function Butterfly({ size, color, style }: CreatureSvgProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 100 60" style={style} fill={color}>
+      <g transform="translate(50,30)">
+        <g className={rig.wing} style={{ transformOrigin: '0 0' }}>
+          <ellipse cx="-16" cy="-8" rx="16" ry="11" />
+          <ellipse cx="-13" cy="7" rx="11" ry="8" />
+        </g>
+      </g>
+      <g transform="translate(50,30)">
+        <g className={rig.wingMirror} style={{ transformOrigin: '0 0' }}>
+          <ellipse cx="16" cy="-8" rx="16" ry="11" />
+          <ellipse cx="13" cy="7" rx="11" ry="8" />
+        </g>
+      </g>
+
+      {/* Body: thorax + abdomen, static. */}
+      <line x1="50" y1="16" x2="50" y2="42" stroke={color} strokeWidth="4" strokeLinecap="round" />
+    </svg>
+  );
+}

--- a/src/components/creatures/Butterfly.tsx
+++ b/src/components/creatures/Butterfly.tsx
@@ -1,27 +1,28 @@
 import rig from './rig.module.scss';
 import type { CreatureSvgProps } from './types';
 
-// A butterfly: each side's fore- and hind-wing move together as one unit,
-// flapping in sync with the opposite side via the same wing/wingMirror
-// pair used for birds.
+// A butterfly, in profile: each side's fore- and hind-wing move together
+// as one unit, spread above/below a horizontal body rather than left/right
+// of a vertical one, flapping in sync via the same wing/wingMirror pair
+// used for birds.
 export default function Butterfly({ size, color, style }: CreatureSvgProps) {
   return (
     <svg width={size} height={size} viewBox="0 0 100 60" style={style} fill={color}>
-      <g transform="translate(50,30)">
+      <g transform="translate(44,30)">
         <g className={rig.wing} style={{ transformOrigin: '0 0' }}>
-          <ellipse cx="-16" cy="-8" rx="16" ry="11" />
-          <ellipse cx="-13" cy="7" rx="11" ry="8" />
+          <ellipse cx="-8" cy="-16" rx="11" ry="16" />
+          <ellipse cx="7" cy="-13" rx="8" ry="11" />
         </g>
       </g>
-      <g transform="translate(50,30)">
+      <g transform="translate(44,30)">
         <g className={rig.wingMirror} style={{ transformOrigin: '0 0' }}>
-          <ellipse cx="16" cy="-8" rx="16" ry="11" />
-          <ellipse cx="13" cy="7" rx="11" ry="8" />
+          <ellipse cx="-8" cy="16" rx="11" ry="16" />
+          <ellipse cx="7" cy="13" rx="8" ry="11" />
         </g>
       </g>
 
       {/* Body: thorax + abdomen, static. */}
-      <line x1="50" y1="16" x2="50" y2="42" stroke={color} strokeWidth="4" strokeLinecap="round" />
+      <line x1="28" y1="30" x2="54" y2="30" stroke={color} strokeWidth="4" strokeLinecap="round" />
     </svg>
   );
 }

--- a/src/components/creatures/Camel.tsx
+++ b/src/components/creatures/Camel.tsx
@@ -1,0 +1,46 @@
+import rig from './rig.module.scss';
+import type { CreatureSvgProps } from './types';
+
+// A walking camel: two legs swinging in opposition (a real diagonal gait,
+// not a symmetric bob) beneath a static torso/hump/neck/head silhouette.
+export default function Camel({ size, color, style }: CreatureSvgProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 100 70" style={style} fill={color}>
+      <g transform="translate(35,45)">
+        <g className={rig.legA} style={{ transformOrigin: '0 0' }}>
+          <line
+            x1="0"
+            y1="0"
+            x2="-7"
+            y2="21"
+            stroke={color}
+            strokeWidth="4.5"
+            strokeLinecap="round"
+          />
+        </g>
+      </g>
+      <g transform="translate(61,45)">
+        <g className={rig.legB} style={{ transformOrigin: '0 0' }}>
+          <line
+            x1="0"
+            y1="0"
+            x2="7"
+            y2="21"
+            stroke={color}
+            strokeWidth="4.5"
+            strokeLinecap="round"
+          />
+        </g>
+      </g>
+
+      {/* Tail */}
+      <line x1="24" y1="34" x2="16" y2="45" stroke={color} strokeWidth="3" strokeLinecap="round" />
+
+      {/* Torso, hump, neck, head — static silhouette. */}
+      <ellipse cx="48" cy="36" rx="23" ry="13" />
+      <ellipse cx="41" cy="21" rx="10" ry="10" />
+      <line x1="64" y1="30" x2="84" y2="8" stroke={color} strokeWidth="9" strokeLinecap="round" />
+      <ellipse cx="87" cy="6" rx="7" ry="5" />
+    </svg>
+  );
+}

--- a/src/components/creatures/Camel.tsx
+++ b/src/components/creatures/Camel.tsx
@@ -11,12 +11,25 @@ export default function Camel({ size, color, style }: CreatureSvgProps) {
           <line
             x1="0"
             y1="0"
-            x2="-7"
-            y2="21"
+            x2="0"
+            y2="11"
             stroke={color}
             strokeWidth="4.5"
             strokeLinecap="round"
           />
+          <g transform="translate(0,11)">
+            <g className={rig.kneeA} style={{ transformOrigin: '0 0' }}>
+              <line
+                x1="0"
+                y1="0"
+                x2="0"
+                y2="11"
+                stroke={color}
+                strokeWidth="4"
+                strokeLinecap="round"
+              />
+            </g>
+          </g>
         </g>
       </g>
       <g transform="translate(61,45)">
@@ -24,12 +37,25 @@ export default function Camel({ size, color, style }: CreatureSvgProps) {
           <line
             x1="0"
             y1="0"
-            x2="7"
-            y2="21"
+            x2="0"
+            y2="11"
             stroke={color}
             strokeWidth="4.5"
             strokeLinecap="round"
           />
+          <g transform="translate(0,11)">
+            <g className={rig.kneeB} style={{ transformOrigin: '0 0' }}>
+              <line
+                x1="0"
+                y1="0"
+                x2="0"
+                y2="11"
+                stroke={color}
+                strokeWidth="4"
+                strokeLinecap="round"
+              />
+            </g>
+          </g>
         </g>
       </g>
 

--- a/src/components/creatures/Dove.tsx
+++ b/src/components/creatures/Dove.tsx
@@ -1,26 +1,26 @@
 import rig from './rig.module.scss';
 import type { CreatureSvgProps } from './types';
 
-// A flying dove/bird: same synchronized wing-pair rig as the hawk, with a
-// rounder body and a small fanned tail.
+// A flying dove/bird, in profile: same synchronized wing-pair rig as the
+// hawk, body horizontal and facing right, with a small fanned tail behind.
 export default function Dove({ size, color, style }: CreatureSvgProps) {
   return (
     <svg width={size} height={size} viewBox="0 0 100 60" style={style} fill={color}>
-      <g transform="translate(50,28)">
+      <g transform="translate(48,30)">
         <g className={rig.wing} style={{ transformOrigin: '0 0' }}>
-          <path d="M 0,0 L -34,-7 L -28,4 L -8,6 Z" />
+          <path d="M 0,0 L -7,-30 L 4,-24 L 6,-7 Z" />
         </g>
       </g>
-      <g transform="translate(50,28)">
+      <g transform="translate(48,30)">
         <g className={rig.wingMirror} style={{ transformOrigin: '0 0' }}>
-          <path d="M 0,0 L 34,-7 L 28,4 L 8,6 Z" />
+          <path d="M 0,0 L -7,30 L 4,24 L 6,7 Z" />
         </g>
       </g>
 
       {/* Body, head, tail — static silhouette. */}
-      <ellipse cx="49" cy="33" rx="9" ry="12" />
-      <circle cx="52" cy="18" r="6.5" />
-      <path d="M 44,42 L 49,54 L 54,42 Z" />
+      <ellipse cx="48" cy="30" rx="13" ry="8" />
+      <circle cx="65" cy="28" r="6.5" />
+      <path d="M 32,24 L 20,30 L 32,36 Z" />
     </svg>
   );
 }

--- a/src/components/creatures/Dove.tsx
+++ b/src/components/creatures/Dove.tsx
@@ -1,0 +1,26 @@
+import rig from './rig.module.scss';
+import type { CreatureSvgProps } from './types';
+
+// A flying dove/bird: same synchronized wing-pair rig as the hawk, with a
+// rounder body and a small fanned tail.
+export default function Dove({ size, color, style }: CreatureSvgProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 100 60" style={style} fill={color}>
+      <g transform="translate(50,28)">
+        <g className={rig.wing} style={{ transformOrigin: '0 0' }}>
+          <path d="M 0,0 L -34,-7 L -28,4 L -8,6 Z" />
+        </g>
+      </g>
+      <g transform="translate(50,28)">
+        <g className={rig.wingMirror} style={{ transformOrigin: '0 0' }}>
+          <path d="M 0,0 L 34,-7 L 28,4 L 8,6 Z" />
+        </g>
+      </g>
+
+      {/* Body, head, tail — static silhouette. */}
+      <ellipse cx="49" cy="33" rx="9" ry="12" />
+      <circle cx="52" cy="18" r="6.5" />
+      <path d="M 44,42 L 49,54 L 54,42 Z" />
+    </svg>
+  );
+}

--- a/src/components/creatures/FishSchool.tsx
+++ b/src/components/creatures/FishSchool.tsx
@@ -1,0 +1,37 @@
+import rig from './rig.module.scss';
+import type { CreatureSvgProps } from './types';
+
+interface FishProps {
+  x: number;
+  y: number;
+  scale: number;
+  color: string;
+  delay: string;
+}
+
+// One small fish: an oval body with a triangular tail swishing from its
+// own base — the building block FishSchool repeats a few times.
+function Fish({ x, y, scale, color, delay }: FishProps) {
+  return (
+    <g transform={`translate(${x},${y}) scale(${scale})`}>
+      <g transform="translate(-2,0)">
+        <g className={rig.tail} style={{ transformOrigin: '0 0', animationDelay: delay }}>
+          <path d="M 0,0 L -11,-6 L -11,6 Z" fill={color} />
+        </g>
+      </g>
+      <ellipse cx="8" cy="0" rx="10" ry="5" fill={color} />
+    </g>
+  );
+}
+
+// A loose school of three fish, each swishing its own tail on a slightly
+// different delay so they don't read as identical clones.
+export default function FishSchool({ size, color, style }: CreatureSvgProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 100 60" style={style}>
+      <Fish x={30} y={22} scale={1} color={color} delay="0s" />
+      <Fish x={54} y={34} scale={0.8} color={color} delay="-0.25s" />
+      <Fish x={22} y={40} scale={0.7} color={color} delay="-0.5s" />
+    </svg>
+  );
+}

--- a/src/components/creatures/Hawk.tsx
+++ b/src/components/creatures/Hawk.tsx
@@ -1,0 +1,28 @@
+import rig from './rig.module.scss';
+import type { CreatureSvgProps } from './types';
+
+// A gliding hawk: two wings flapping together (a fast, deep downstroke and
+// a slower recovery) from a shared shoulder point, either side of a static
+// body/head/tail silhouette.
+export default function Hawk({ size, color, style }: CreatureSvgProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 100 60" style={style} fill={color}>
+      <g transform="translate(50,26)">
+        <g className={rig.wing} style={{ transformOrigin: '0 0' }}>
+          <path d="M 0,0 L -38,-9 L -32,3 L -10,7 Z" />
+        </g>
+      </g>
+      <g transform="translate(50,26)">
+        <g className={rig.wingMirror} style={{ transformOrigin: '0 0' }}>
+          <path d="M 0,0 L 38,-9 L 32,3 L 10,7 Z" />
+        </g>
+      </g>
+
+      {/* Body, head, beak, tail — static silhouette. */}
+      <ellipse cx="50" cy="32" rx="7" ry="14" />
+      <circle cx="50" cy="15" r="6" />
+      <path d="M 47,10 L 40,12 L 47,15 Z" />
+      <path d="M 44,44 L 50,58 L 56,44 Z" />
+    </svg>
+  );
+}

--- a/src/components/creatures/Hawk.tsx
+++ b/src/components/creatures/Hawk.tsx
@@ -1,28 +1,29 @@
 import rig from './rig.module.scss';
 import type { CreatureSvgProps } from './types';
 
-// A gliding hawk: two wings flapping together (a fast, deep downstroke and
-// a slower recovery) from a shared shoulder point, either side of a static
-// body/head/tail silhouette.
+// A gliding hawk, seen in profile: body horizontal with the head facing
+// right (the default drift direction), wings spread above and below the
+// shoulder rather than left/right — a bird moving sideways across the
+// screen has to face sideways too, not stand on end.
 export default function Hawk({ size, color, style }: CreatureSvgProps) {
   return (
     <svg width={size} height={size} viewBox="0 0 100 60" style={style} fill={color}>
-      <g transform="translate(50,26)">
+      <g transform="translate(46,30)">
         <g className={rig.wing} style={{ transformOrigin: '0 0' }}>
-          <path d="M 0,0 L -38,-9 L -32,3 L -10,7 Z" />
+          <path d="M 0,0 L -8,-32 L 4,-26 L 8,-8 Z" />
         </g>
       </g>
-      <g transform="translate(50,26)">
+      <g transform="translate(46,30)">
         <g className={rig.wingMirror} style={{ transformOrigin: '0 0' }}>
-          <path d="M 0,0 L 38,-9 L 32,3 L 10,7 Z" />
+          <path d="M 0,0 L -8,32 L 4,26 L 8,8 Z" />
         </g>
       </g>
 
       {/* Body, head, beak, tail — static silhouette. */}
-      <ellipse cx="50" cy="32" rx="7" ry="14" />
-      <circle cx="50" cy="15" r="6" />
-      <path d="M 47,10 L 40,12 L 47,15 Z" />
-      <path d="M 44,44 L 50,58 L 56,44 Z" />
+      <ellipse cx="46" cy="30" rx="16" ry="7" />
+      <circle cx="66" cy="28" r="6" />
+      <path d="M 70,25 L 79,28 L 70,31 Z" />
+      <path d="M 32,24 L 18,30 L 32,36 Z" />
     </svg>
   );
 }

--- a/src/components/creatures/Jellyfish.tsx
+++ b/src/components/creatures/Jellyfish.tsx
@@ -1,0 +1,37 @@
+import rig from './rig.module.scss';
+import type { CreatureSvgProps } from './types';
+
+const TENTACLE_X = [-16, -8, 0, 8, 16];
+
+// A jellyfish: a dome bell pulsing for propulsion, trailing a fan of
+// tentacles that wave on staggered delays.
+export default function Jellyfish({ size, color, style }: CreatureSvgProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 100 60" style={style} fill={color}>
+      {TENTACLE_X.map((dx, i) => (
+        <g key={dx} transform={`translate(${50 + dx},28)`}>
+          <g
+            className={rig.tentacle}
+            style={{ transformOrigin: '0 0', animationDelay: `${i * -0.16}s` }}
+          >
+            <line
+              x1="0"
+              y1="0"
+              x2="0"
+              y2="26"
+              stroke={color}
+              strokeWidth="3"
+              strokeLinecap="round"
+            />
+          </g>
+        </g>
+      ))}
+
+      <g transform="translate(50,18)">
+        <g className={rig.pulse} style={{ transformOrigin: '0 0' }}>
+          <path d="M -22,4 C -22,-14 22,-14 22,4 C 14,10 -14,10 -22,4 Z" />
+        </g>
+      </g>
+    </svg>
+  );
+}

--- a/src/components/creatures/MantaRay.tsx
+++ b/src/components/creatures/MantaRay.tsx
@@ -1,29 +1,30 @@
 import rig from './rig.module.scss';
 import type { CreatureSvgProps } from './types';
 
-// An alien sky-manta gliding through the aurora: broad, flat wings undulate
-// slowly together, with a long thin tail trailing behind.
+// An alien sky-manta gliding through the aurora, in profile: broad, flat
+// wings spread above/below the body and undulate slowly together, with a
+// long thin tail trailing behind (left) as it glides rightward.
 export default function MantaRay({ size, color, style }: CreatureSvgProps) {
   return (
     <svg width={size} height={size} viewBox="0 0 100 60" style={style} fill={color}>
       <g transform="translate(48,30)">
         <g className={rig.wingSlow} style={{ transformOrigin: '0 0' }}>
-          <path d="M 0,-4 L -40,-14 L -36,4 L -8,8 Z" />
+          <path d="M -4,0 L -14,-40 L 4,-36 L 8,-8 Z" />
         </g>
       </g>
       <g transform="translate(48,30)">
         <g className={rig.wingSlowMirror} style={{ transformOrigin: '0 0' }}>
-          <path d="M 0,-4 L 40,-14 L 36,4 L 8,8 Z" />
+          <path d="M -4,0 L -14,40 L 4,36 L 8,8 Z" />
         </g>
       </g>
 
       {/* Body and tail — static silhouette. */}
-      <ellipse cx="48" cy="30" rx="9" ry="7" />
+      <ellipse cx="48" cy="30" rx="8" ry="8" />
       <line
-        x1="54"
-        y1="34"
-        x2="80"
-        y2="46"
+        x1="41"
+        y1="31"
+        x2="16"
+        y2="38"
         stroke={color}
         strokeWidth="2.5"
         strokeLinecap="round"

--- a/src/components/creatures/MantaRay.tsx
+++ b/src/components/creatures/MantaRay.tsx
@@ -1,0 +1,33 @@
+import rig from './rig.module.scss';
+import type { CreatureSvgProps } from './types';
+
+// An alien sky-manta gliding through the aurora: broad, flat wings undulate
+// slowly together, with a long thin tail trailing behind.
+export default function MantaRay({ size, color, style }: CreatureSvgProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 100 60" style={style} fill={color}>
+      <g transform="translate(48,30)">
+        <g className={rig.wingSlow} style={{ transformOrigin: '0 0' }}>
+          <path d="M 0,-4 L -40,-14 L -36,4 L -8,8 Z" />
+        </g>
+      </g>
+      <g transform="translate(48,30)">
+        <g className={rig.wingSlowMirror} style={{ transformOrigin: '0 0' }}>
+          <path d="M 0,-4 L 40,-14 L 36,4 L 8,8 Z" />
+        </g>
+      </g>
+
+      {/* Body and tail — static silhouette. */}
+      <ellipse cx="48" cy="30" rx="9" ry="7" />
+      <line
+        x1="54"
+        y1="34"
+        x2="80"
+        y2="46"
+        stroke={color}
+        strokeWidth="2.5"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}

--- a/src/components/creatures/PolarBear.tsx
+++ b/src/components/creatures/PolarBear.tsx
@@ -11,12 +11,25 @@ export default function PolarBear({ size, color, style }: CreatureSvgProps) {
           <line
             x1="0"
             y1="0"
-            x2="-6"
-            y2="17"
+            x2="0"
+            y2="9"
             stroke={color}
             strokeWidth="6.5"
             strokeLinecap="round"
           />
+          <g transform="translate(0,9)">
+            <g className={rig.kneeA} style={{ transformOrigin: '0 0' }}>
+              <line
+                x1="0"
+                y1="0"
+                x2="0"
+                y2="9"
+                stroke={color}
+                strokeWidth="6"
+                strokeLinecap="round"
+              />
+            </g>
+          </g>
         </g>
       </g>
       <g transform="translate(63,42)">
@@ -24,12 +37,25 @@ export default function PolarBear({ size, color, style }: CreatureSvgProps) {
           <line
             x1="0"
             y1="0"
-            x2="6"
-            y2="17"
+            x2="0"
+            y2="9"
             stroke={color}
             strokeWidth="6.5"
             strokeLinecap="round"
           />
+          <g transform="translate(0,9)">
+            <g className={rig.kneeB} style={{ transformOrigin: '0 0' }}>
+              <line
+                x1="0"
+                y1="0"
+                x2="0"
+                y2="9"
+                stroke={color}
+                strokeWidth="6"
+                strokeLinecap="round"
+              />
+            </g>
+          </g>
         </g>
       </g>
 

--- a/src/components/creatures/PolarBear.tsx
+++ b/src/components/creatures/PolarBear.tsx
@@ -1,0 +1,44 @@
+import rig from './rig.module.scss';
+import type { CreatureSvgProps } from './types';
+
+// A walking bear: same opposed-leg-swing rig as the camel, under a
+// rounder, shorter-necked silhouette.
+export default function PolarBear({ size, color, style }: CreatureSvgProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 100 60" style={style} fill={color}>
+      <g transform="translate(33,42)">
+        <g className={rig.legA} style={{ transformOrigin: '0 0' }}>
+          <line
+            x1="0"
+            y1="0"
+            x2="-6"
+            y2="17"
+            stroke={color}
+            strokeWidth="6.5"
+            strokeLinecap="round"
+          />
+        </g>
+      </g>
+      <g transform="translate(63,42)">
+        <g className={rig.legB} style={{ transformOrigin: '0 0' }}>
+          <line
+            x1="0"
+            y1="0"
+            x2="6"
+            y2="17"
+            stroke={color}
+            strokeWidth="6.5"
+            strokeLinecap="round"
+          />
+        </g>
+      </g>
+
+      {/* Torso, neck, head, ears — static silhouette. */}
+      <ellipse cx="46" cy="32" rx="25" ry="15" />
+      <line x1="66" y1="26" x2="76" y2="18" stroke={color} strokeWidth="13" strokeLinecap="round" />
+      <circle cx="80" cy="15" r="9" />
+      <circle cx="74" cy="7" r="3" />
+      <circle cx="86" cy="7" r="3" />
+    </svg>
+  );
+}

--- a/src/components/creatures/SandWorm.tsx
+++ b/src/components/creatures/SandWorm.tsx
@@ -1,0 +1,35 @@
+import rig from './rig.module.scss';
+import type { CreatureSvgProps } from './types';
+
+// A chain of overlapping segments, each pivoting from its own anchor with a
+// phase-delayed copy of the same rotation keyframe — the delay is what
+// makes the bend visibly travel down the body as a wave, rather than every
+// segment rocking in lockstep.
+const SEGMENTS = [0, 1, 2, 3];
+const SEGMENT_SPACING = 20;
+const SEGMENT_LENGTH = 26;
+
+export default function SandWorm({ size, color, style }: CreatureSvgProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 100 36" style={style} fill={color}>
+      {SEGMENTS.map((i) => (
+        <g key={i} transform={`translate(${8 + i * SEGMENT_SPACING},18)`}>
+          <g
+            className={rig.segment}
+            style={{ transformOrigin: '0 0', animationDelay: `${i * -0.22}s` }}
+          >
+            <line
+              x1="0"
+              y1="0"
+              x2={SEGMENT_LENGTH}
+              y2="0"
+              stroke={color}
+              strokeWidth={12 - i * 1.6}
+              strokeLinecap="round"
+            />
+          </g>
+        </g>
+      ))}
+    </svg>
+  );
+}

--- a/src/components/creatures/Squid.tsx
+++ b/src/components/creatures/Squid.tsx
@@ -1,0 +1,35 @@
+import rig from './rig.module.scss';
+import type { CreatureSvgProps } from './types';
+
+const TENTACLE_X = [36, 43, 50, 57, 64];
+
+// A squid: a mantle/head silhouette over a fan of trailing tentacles, each
+// waving on its own delay so the motion visibly ripples across the fan
+// rather than every tentacle swinging in lockstep.
+export default function Squid({ size, color, style }: CreatureSvgProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 100 60" style={style} fill={color}>
+      {TENTACLE_X.map((x, i) => (
+        <g key={x} transform={`translate(${x},30)`}>
+          <g
+            className={rig.tentacle}
+            style={{ transformOrigin: '0 0', animationDelay: `${i * -0.14}s` }}
+          >
+            <line
+              x1="0"
+              y1="0"
+              x2="0"
+              y2="24"
+              stroke={color}
+              strokeWidth="3.5"
+              strokeLinecap="round"
+            />
+          </g>
+        </g>
+      ))}
+
+      {/* Mantle — static silhouette. */}
+      <path d="M 50,2 C 62,2 70,14 70,26 C 70,34 62,32 50,32 C 38,32 30,34 30,26 C 30,14 38,2 50,2 Z" />
+    </svg>
+  );
+}

--- a/src/components/creatures/Whale.tsx
+++ b/src/components/creatures/Whale.tsx
@@ -1,0 +1,21 @@
+import rig from './rig.module.scss';
+import type { CreatureSvgProps } from './types';
+
+// A swimming whale: a wide, flat tail fluke swishing up and down from its
+// own base (the same rotating `.tail` rig as the fish, just oriented
+// horizontally so the same left/right rotation reads as an up/down stroke).
+export default function Whale({ size, color, style }: CreatureSvgProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 100 50" style={style} fill={color}>
+      <g transform="translate(64,25)">
+        <g className={rig.tail} style={{ transformOrigin: '0 0', animationDuration: '1.6s' }}>
+          <path d="M 0,0 L 22,-9 L 16,0 L 22,9 Z" />
+        </g>
+      </g>
+
+      {/* Body and dorsal fin — static silhouette. */}
+      <ellipse cx="34" cy="25" rx="30" ry="12" />
+      <path d="M 30,13 L 38,2 L 44,14 Z" />
+    </svg>
+  );
+}

--- a/src/components/creatures/Wyvern.tsx
+++ b/src/components/creatures/Wyvern.tsx
@@ -1,27 +1,29 @@
 import rig from './rig.module.scss';
 import type { CreatureSvgProps } from './types';
 
-// A gliding wyvern: broader, more angular bat-like wings than the hawk's,
-// flapping slowly together, plus a long tail trailing behind.
+// A gliding wyvern, in profile: broader, more angular bat-like wings than
+// the hawk's, spread above/below the shoulder and flapping slowly
+// together, with a long tail trailing behind (left) and the head facing
+// right (the default drift direction).
 export default function Wyvern({ size, color, style }: CreatureSvgProps) {
   return (
     <svg width={size} height={size} viewBox="0 0 100 60" style={style} fill={color}>
-      <g transform="translate(48,28)">
+      <g transform="translate(48,30)">
         <g className={rig.wingSlow} style={{ transformOrigin: '0 0' }}>
-          <path d="M 0,0 L -30,-16 L -40,-4 L -28,2 L -34,8 L -14,6 Z" />
+          <path d="M 0,0 L -16,-30 L -4,-40 L 2,-28 L 8,-34 L 6,-14 Z" />
         </g>
       </g>
-      <g transform="translate(48,28)">
+      <g transform="translate(48,30)">
         <g className={rig.wingSlowMirror} style={{ transformOrigin: '0 0' }}>
-          <path d="M 0,0 L 30,-16 L 40,-4 L 28,2 L 34,8 L 14,6 Z" />
+          <path d="M 0,0 L -16,30 L -4,40 L 2,28 L 8,34 L 6,14 Z" />
         </g>
       </g>
 
-      {/* Body, head, tail — static silhouette. */}
-      <path d="M 34,44 C 26,50 18,52 10,48 C 20,44 26,38 30,30 Z" />
-      <ellipse cx="50" cy="32" rx="9" ry="13" />
-      <circle cx="52" cy="14" r="6" />
-      <path d="M 48,10 L 42,8 L 49,15 Z" />
+      {/* Body, tail, head — static silhouette. */}
+      <path d="M 36,34 C 28,26 18,22 8,30 C 18,32 26,34 32,40 Z" />
+      <ellipse cx="50" cy="30" rx="15" ry="8" />
+      <circle cx="68" cy="28" r="6" />
+      <path d="M 71,24 L 78,20 L 70,29 Z" />
     </svg>
   );
 }

--- a/src/components/creatures/Wyvern.tsx
+++ b/src/components/creatures/Wyvern.tsx
@@ -1,0 +1,27 @@
+import rig from './rig.module.scss';
+import type { CreatureSvgProps } from './types';
+
+// A gliding wyvern: broader, more angular bat-like wings than the hawk's,
+// flapping slowly together, plus a long tail trailing behind.
+export default function Wyvern({ size, color, style }: CreatureSvgProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 100 60" style={style} fill={color}>
+      <g transform="translate(48,28)">
+        <g className={rig.wingSlow} style={{ transformOrigin: '0 0' }}>
+          <path d="M 0,0 L -30,-16 L -40,-4 L -28,2 L -34,8 L -14,6 Z" />
+        </g>
+      </g>
+      <g transform="translate(48,28)">
+        <g className={rig.wingSlowMirror} style={{ transformOrigin: '0 0' }}>
+          <path d="M 0,0 L 30,-16 L 40,-4 L 28,2 L 34,8 L 14,6 Z" />
+        </g>
+      </g>
+
+      {/* Body, head, tail — static silhouette. */}
+      <path d="M 34,44 C 26,50 18,52 10,48 C 20,44 26,38 30,30 Z" />
+      <ellipse cx="50" cy="32" rx="9" ry="13" />
+      <circle cx="52" cy="14" r="6" />
+      <path d="M 48,10 L 42,8 L 49,15 Z" />
+    </svg>
+  );
+}

--- a/src/components/creatures/rig.module.scss
+++ b/src/components/creatures/rig.module.scss
@@ -1,0 +1,204 @@
+// Shared animation classes for every rigged creature below. Each creature
+// nests every animatable part as `<g transform="translate(pivotX,pivotY)">
+// <g className={styles.legA} style={{transformOrigin:'0 0'}}>...shape drawn
+// from local (0,0)...</g></g>` — the outer g's plain SVG `transform`
+// attribute places the pivot (a hip, a shoulder, a tail base) in the
+// overall coordinate space, and the inner g's CSS `transform` rotates
+// around that same local (0,0), so a part visibly pivots like a real joint
+// instead of the whole silhouette wobbling as one rigid shape.
+//
+// Only `transform` is animated here; each creature component is responsible
+// for not layering a second transform-animation on the exact same element
+// (the lesson from Creature.module.scss's own track/wander/icon split).
+
+// Two legs (or two leg-pairs, seen from the side) swinging in opposition —
+// a real diagonal quadruped gait, not a single symmetric bob. `-a` swings
+// forward while `-b` swings back, then they reverse.
+@keyframes legSwingA {
+  0%,
+  100% {
+    transform: rotate(16deg);
+  }
+
+  50% {
+    transform: rotate(-16deg);
+  }
+}
+
+@keyframes legSwingB {
+  0%,
+  100% {
+    transform: rotate(-16deg);
+  }
+
+  50% {
+    transform: rotate(16deg);
+  }
+}
+
+.legA {
+  animation: legSwingA 1.1s ease-in-out infinite;
+}
+
+.legB {
+  animation: legSwingB 1.1s ease-in-out infinite;
+}
+
+// A wingbeat: fast, deep downstroke, a slight overshoot on the recovery,
+// then a brief settle before the next beat — not a symmetric pulse. A left
+// wing (drawn extending toward -x from its shoulder) and a right wing
+// (drawn extending toward +x) need opposite-signed rotation to swing the
+// *same visual direction* together — a shared positive rotation angle
+// would lift one while dropping the other, like a seesaw, since they're
+// mirror images of each other. `.wing` is the left/base version; `.wingMirror`
+// carries the identical timing with every angle sign-flipped.
+@keyframes wingFlap {
+  0% {
+    transform: rotate(0deg);
+  }
+
+  22% {
+    transform: rotate(-52deg);
+  }
+
+  45% {
+    transform: rotate(8deg);
+  }
+
+  70% {
+    transform: rotate(-6deg);
+  }
+
+  100% {
+    transform: rotate(0deg);
+  }
+}
+
+@keyframes wingFlapMirror {
+  0% {
+    transform: rotate(0deg);
+  }
+
+  22% {
+    transform: rotate(52deg);
+  }
+
+  45% {
+    transform: rotate(-8deg);
+  }
+
+  70% {
+    transform: rotate(6deg);
+  }
+
+  100% {
+    transform: rotate(0deg);
+  }
+}
+
+.wing {
+  animation: wingFlap 0.6s infinite;
+  animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.wingMirror {
+  animation: wingFlapMirror 0.6s infinite;
+  animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+// A slower, gentler flap for gliding/soaring creatures (manta, wyvern)
+// rather than the quick wingbeat above.
+.wingSlow {
+  animation: wingFlap 1.6s infinite;
+  animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.wingSlowMirror {
+  animation: wingFlapMirror 1.6s infinite;
+  animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+// A tail fin swishing side to side to drive a swim stroke.
+@keyframes tailSwish {
+  0%,
+  100% {
+    transform: rotate(-22deg);
+  }
+
+  50% {
+    transform: rotate(22deg);
+  }
+}
+
+.tail {
+  animation: tailSwish 0.9s ease-in-out infinite;
+}
+
+// A trailing tentacle/appendage wave — each tentacle uses the same
+// keyframe but with its own animation-delay (set inline per instance) so
+// the wave visibly travels down the chain rather than every tentacle
+// moving in lockstep.
+@keyframes tentacleWave {
+  0%,
+  100% {
+    transform: rotate(-14deg);
+  }
+
+  50% {
+    transform: rotate(14deg);
+  }
+}
+
+.tentacle {
+  animation: tentacleWave 1.8s ease-in-out infinite;
+}
+
+// A body-segment undulation for serpentine creatures (the sandworm) —
+// alternating rotation per segment, each on its own delay, produces a
+// traveling S-curve down the chain.
+@keyframes segmentWave {
+  0%,
+  100% {
+    transform: rotate(-10deg);
+  }
+
+  50% {
+    transform: rotate(10deg);
+  }
+}
+
+.segment {
+  animation: segmentWave 1.4s ease-in-out infinite;
+}
+
+// A gentle bell pulse for jellyfish-style propulsion — contract, then
+// relax, unlike a limb's back-and-forth swing.
+@keyframes pulse {
+  0%,
+  100% {
+    transform: scaleY(1);
+  }
+
+  50% {
+    transform: scaleY(0.8);
+  }
+}
+
+.pulse {
+  animation: pulse 1.8s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .legA,
+  .legB,
+  .wing,
+  .wingMirror,
+  .wingSlow,
+  .wingSlowMirror,
+  .tail,
+  .tentacle,
+  .segment,
+  .pulse {
+    animation: none;
+  }
+}

--- a/src/components/creatures/rig.module.scss
+++ b/src/components/creatures/rig.module.scss
@@ -44,6 +44,44 @@
   animation: legSwingB 1.1s ease-in-out infinite;
 }
 
+// A knee joint nested inside each leg (a second segment, translated to the
+// first segment's own end) — a single rigid leg swinging from one pivot
+// reads as a stiff pendulum, not a walk. The knee bends only during its
+// own leg's forward/lift half of the stride and stays straight through the
+// planted/push half, timed to the *same* 1.1s cycle as legSwingA/B so the
+// bend and the swing stay locked together.
+@keyframes kneeBendA {
+  0%,
+  50%,
+  100% {
+    transform: rotate(0deg);
+  }
+
+  25% {
+    transform: rotate(30deg);
+  }
+}
+
+@keyframes kneeBendB {
+  0%,
+  50%,
+  100% {
+    transform: rotate(0deg);
+  }
+
+  75% {
+    transform: rotate(30deg);
+  }
+}
+
+.kneeA {
+  animation: kneeBendA 1.1s ease-in-out infinite;
+}
+
+.kneeB {
+  animation: kneeBendB 1.1s ease-in-out infinite;
+}
+
 // A wingbeat: fast, deep downstroke, a slight overshoot on the recovery,
 // then a brief settle before the next beat — not a symmetric pulse. A left
 // wing (drawn extending toward -x from its shoulder) and a right wing
@@ -191,6 +229,8 @@
 @media (prefers-reduced-motion: reduce) {
   .legA,
   .legB,
+  .kneeA,
+  .kneeB,
   .wing,
   .wingMirror,
   .wingSlow,

--- a/src/components/creatures/types.ts
+++ b/src/components/creatures/types.ts
@@ -1,0 +1,9 @@
+import type { CSSProperties } from 'react';
+
+// Every rigged creature below implements this shape so Creature.tsx can
+// render Normal/Alien interchangeably regardless of which creature they are.
+export interface CreatureSvgProps {
+  size: number;
+  color: string;
+  style?: CSSProperties;
+}


### PR DESCRIPTION
## Summary
- First pass: replaced the symmetric, single-property ease-in-out pulses driving each creature's gait with multi-stage, asymmetric keyframes (a wingbeat's fast downstroke + slower recovery, a quadruped's two-peaks-per-stride walk, a traveling-wave undulation) plus an independent "wander" layer for airborne/aquatic creatures.
- That still wasn't enough — a flat single-path icon can only ever wobble as one rigid shape, since there's nothing to animate independently within it. Each creature is now a small hand-authored SVG with a static body plus separately-animated parts, each pivoting from its own actual joint (hip, shoulder, tail base) via a nested translate-then-rotate group:
  - **Walkers** (camel, polar bear): two legs swinging in opposition — a real diagonal gait.
  - **Flyers** (hawk/wyvern, dove/butterfly, manta ray): a wing pair flapping together, fast downstroke + slower recovery.
  - **Swimmers** (fish school, whale): a tail fin/fluke swishing from its base.
  - **Trailing appendages** (squid, jellyfish, sandworm): a chain of parts each on its own delay, so motion visibly travels down the chain.
- This drops the `react-icons` dependency entirely (net bundle size decrease) since creatures are no longer icon components.

## Test plan
- [x] `tsc --noEmit`, `eslint`, `prettier --check` pass
- [x] `vitest run --coverage` passes, coverage above configured thresholds
- [x] `vite build` succeeds
- [x] Verified via computed `transform` matrices that gait keyframes progress correctly frame-by-frame
- [x] Visually confirmed leg-swing (camel), wing-flap (hawk, dove), and tentacle-wave (jellyfish) rigs against a production build — legs alternate, wings go from folded to fully spread, tentacles ripple with a traveling delay
- [x] Confirmed reduced-motion still freezes every new animation (legs, wings, tails, tentacles, wander)