### PR TITLE
Fix bird top-down look and let burn smoke escape the modal

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -136,15 +136,21 @@ export default function App() {
               <FontAwesomeIcon icon={faXmark} />
             </button>
           )}
-          {burning && (
-            <BurnTransition
-              sourceNodeRef={resumeRef}
-              onComplete={handleBurnComplete}
-              onReady={handleBurnReady}
-              durationMs={1600}
-            />
-          )}
         </div>
+      )}
+      {/* A sibling of .modal, not a child — .modal has overflow:hidden for
+          its ordinary (non-burning) layout, which would otherwise clip the
+          burn's smoke dead at the résumé's own edges. This canvas covers
+          the whole viewport instead and is told where the résumé itself
+          sits (see BurnTransition.tsx's uRect), so the paper still burns in
+          exactly the same place. */}
+      {burning && (
+        <BurnTransition
+          sourceNodeRef={resumeRef}
+          onComplete={handleBurnComplete}
+          onReady={handleBurnReady}
+          durationMs={1600}
+        />
       )}
       <Routes>
         <Route path="/" element={<Grid />} />

--- a/src/components/BurnTransition.module.scss
+++ b/src/components/BurnTransition.module.scss
@@ -1,10 +1,16 @@
+// Covers the whole viewport rather than just the modal's own box — the
+// résumé's paper still burns in exactly the same place (see burn.frag's
+// uRect), but smoke can now drift past the modal's edges instead of being
+// clipped by its overflow:hidden. A sibling of .modal in App.tsx, not a
+// child of it, precisely so that clipping never applies here.
 .canvas {
-  position: absolute;
+  position: fixed;
   inset: 0;
-  width: 100%;
-  height: 100%;
   display: block;
-  // Above .close (z-index: 2) — occludes the (now-hidden) live resume and
+  // Purely visual — never intercepts clicks meant for the taskbar or
+  // whatever's beneath it, even while it's covering the whole screen.
+  pointer-events: none;
+  // Above .modal (z-index: 1) — occludes the (now-hidden) live resume and
   // the modal's own background purely through paint order.
-  z-index: 3;
+  z-index: 2;
 }

--- a/src/components/BurnTransition.tsx
+++ b/src/components/BurnTransition.tsx
@@ -219,9 +219,14 @@ export default function BurnTransition({
         return;
       }
 
+      // The canvas covers the whole viewport, not just the résumé's own box
+      // (see BurnTransition.module.scss) — the modal it used to be sized to
+      // has overflow:hidden, which clipped the smoke dead at the paper's
+      // edges. uRect (below) tells the shader where that paper actually is
+      // within this larger canvas.
       const dpr = Math.min(window.devicePixelRatio || 1, 2);
-      const width = Math.max(1, Math.round(sourceNode.clientWidth * dpr));
-      const height = Math.max(1, Math.round(sourceNode.clientHeight * dpr));
+      const width = Math.max(1, Math.round(window.innerWidth * dpr));
+      const height = Math.max(1, Math.round(window.innerHeight * dpr));
       canvas.width = width;
       canvas.height = height;
 
@@ -248,6 +253,7 @@ export default function BurnTransition({
 
       const aPosition = gl.getAttribLocation(program, 'aPosition');
       const uResolution = gl.getUniformLocation(program, 'uResolution');
+      const uRect = gl.getUniformLocation(program, 'uRect');
       const uProgress = gl.getUniformLocation(program, 'uProgress');
       const uSeed = gl.getUniformLocation(program, 'uSeed');
       const uOrigin = gl.getUniformLocation(program, 'uOrigin');
@@ -267,13 +273,26 @@ export default function BurnTransition({
       gl.bindTexture(gl.TEXTURE_2D, texture);
       gl.uniform1i(uTexture, 0);
 
-      // Runs past 1 so the fire has time to fully sweep every corner
-      // (worst case, for an ignition point in one corner, is just past 1.2)
-      // before burn.frag's own final dissolve (the last ~28% of this range)
-      // kicks in — smoke no longer decays on its own, so this cutoff is
-      // sized for "fire fully spread, then one clean fade," not "wait for
-      // per-pixel decay to finish."
-      const finishAt = 1.8;
+      // Where the résumé itself sits within this viewport-sized canvas, in
+      // the same bottom-up 0..1 space gl_FragCoord uses (getBoundingClientRect
+      // is top-down from the viewport, hence the y flip). Computed once,
+      // same as the canvas size above — this is a one-shot close transition,
+      // not something that needs to track a mid-burn window resize.
+      const nodeRect = sourceNode.getBoundingClientRect();
+      const rectX0 = (nodeRect.left * dpr) / width;
+      const rectX1 = ((nodeRect.left + nodeRect.width) * dpr) / width;
+      const rectY0 = 1 - ((nodeRect.top + nodeRect.height) * dpr) / height;
+      const rectY1 = 1 - (nodeRect.top * dpr) / height;
+      gl.uniform4f(uRect, rectX0, rectY0, rectX1, rectY1);
+
+      // Runs way past 1 so smoke keeps drifting long after the paper itself
+      // has fully burned away (which still finishes around progress 1, at
+      // the same pace as before) before burn.frag's own final dissolve (the
+      // last ~15% of this range) kicks in — smoke no longer decays on its
+      // own, so this cutoff is sized for "let it hang in the air for a
+      // while, then one clean fade," not "wait for per-pixel decay to
+      // finish."
+      const finishAt = 9;
       gl.uniform1f(uFinishAt, finishAt);
 
       const loop = (now: number) => {

--- a/src/components/creatures/Dove.tsx
+++ b/src/components/creatures/Dove.tsx
@@ -1,19 +1,16 @@
 import rig from './rig.module.scss';
 import type { CreatureSvgProps } from './types';
 
-// A flying dove/bird, in profile: same synchronized wing-pair rig as the
-// hawk, body horizontal and facing right, with a small fanned tail behind.
+// A flying dove/bird, seen in true side profile like the hawk: body
+// horizontal and facing right, a single wing swept up from the shoulder
+// (see Hawk.tsx for why this isn't a mirrored pair above and below the
+// body), with a small fanned tail behind.
 export default function Dove({ size, color, style }: CreatureSvgProps) {
   return (
     <svg width={size} height={size} viewBox="0 0 100 60" style={style} fill={color}>
-      <g transform="translate(48,30)">
+      <g transform="translate(46,26)">
         <g className={rig.wing} style={{ transformOrigin: '0 0' }}>
-          <path d="M 0,0 L -7,-30 L 4,-24 L 6,-7 Z" />
-        </g>
-      </g>
-      <g transform="translate(48,30)">
-        <g className={rig.wingMirror} style={{ transformOrigin: '0 0' }}>
-          <path d="M 0,0 L -7,30 L 4,24 L 6,7 Z" />
+          <path d="M 0,0 L -7,-22 L 3,-17 L 5,-4 Z" />
         </g>
       </g>
 

--- a/src/components/creatures/Hawk.tsx
+++ b/src/components/creatures/Hawk.tsx
@@ -1,29 +1,27 @@
 import rig from './rig.module.scss';
 import type { CreatureSvgProps } from './types';
 
-// A gliding hawk, seen in profile: body horizontal with the head facing
-// right (the default drift direction), wings spread above and below the
-// shoulder rather than left/right — a bird moving sideways across the
-// screen has to face sideways too, not stand on end.
+// A gliding hawk, seen in true side profile: body horizontal with the head
+// facing right (the default drift direction), a single wing swept up from
+// the shoulder. From the side, the near and far wing mostly overlap into
+// one silhouette — mirroring a second wing below the shoulder (the previous
+// version of this component) instead reads as a dorsal/top-down view, since
+// that's exactly how a bird's left and right wings are arranged when seen
+// from above with the body axis drawn horizontally.
 export default function Hawk({ size, color, style }: CreatureSvgProps) {
   return (
     <svg width={size} height={size} viewBox="0 0 100 60" style={style} fill={color}>
-      <g transform="translate(46,30)">
+      <g transform="translate(44,27)">
         <g className={rig.wingSlow} style={{ transformOrigin: '0 0' }}>
-          <path d="M 0,0 L -8,-32 L 4,-26 L 8,-8 Z" />
-        </g>
-      </g>
-      <g transform="translate(46,30)">
-        <g className={rig.wingSlowMirror} style={{ transformOrigin: '0 0' }}>
-          <path d="M 0,0 L -8,32 L 4,26 L 8,8 Z" />
+          <path d="M 0,0 L -9,-25 L 3,-19 L 7,-5 Z" />
         </g>
       </g>
 
       {/* Body, head, beak, tail — static silhouette. */}
-      <ellipse cx="46" cy="30" rx="16" ry="7" />
-      <circle cx="66" cy="28" r="6" />
-      <path d="M 70,25 L 79,28 L 70,31 Z" />
-      <path d="M 32,24 L 18,30 L 32,36 Z" />
+      <ellipse cx="46" cy="32" rx="16" ry="6" />
+      <circle cx="66" cy="30" r="6" />
+      <path d="M 70,27 L 79,30 L 70,33 Z" />
+      <path d="M 32,26 L 18,32 L 32,38 Z" />
     </svg>
   );
 }

--- a/src/shaders/burn.frag
+++ b/src/shaders/burn.frag
@@ -11,13 +11,22 @@
 // The fire radiates outward from a random point on the page (uOrigin)
 // rather than sweeping edge to edge, and the paper warps/darkens slightly
 // just ahead of the front to read as curling away rather than dissolving flat.
+//
+// This canvas now covers the whole viewport rather than just the résumé's
+// own box (see BurnTransition.tsx) so smoke can drift beyond the paper's
+// edges instead of being clipped by the modal's overflow:hidden. uRect is
+// where that paper actually lives within this larger canvas (0..1, in the
+// same bottom-up space as gl_FragCoord) — the fire/char/paper logic below
+// only ever runs inside it, exactly as when the canvas was rect-sized, and
+// everything outside it is smoke (or nothing) drifting across open space.
 precision highp float;
 
 uniform sampler2D uTexture;
 uniform vec2 uResolution;
+uniform vec4 uRect; // paper's on-screen box within this canvas: x0,y0,x1,y1
 uniform float uProgress; // 0 (untouched) -> past 1 (fully gone)
 uniform float uSeed;
-uniform vec2 uOrigin; // ignition point, plain 0..1 uv space
+uniform vec2 uOrigin; // ignition point, plain 0..1 uv space within uRect
 uniform float uFinishAt; // matches BurnTransition.jsx's completion cutoff
 
 // --- noise (ported from landscape.frag) ---------------------------------
@@ -50,17 +59,63 @@ float fbm2(vec2 p) {
   return sum;
 }
 
+// Smoke: a thick wispy trail that rises just behind the char front and
+// stays fully present — no per-pixel decay — so every burn visibly leaves
+// smoke hanging in the air instead of watching it dissipate mid-animation.
+// `front`/`dist` are the same radial burn-front values as the paper itself
+// uses, just evaluated arbitrarily far outside uRect too (auv is a plain
+// affine extension of the paper's own coordinate space — see main()) so the
+// smoke can keep drifting past the paper's edges rather than stopping dead
+// at them. `reachMask` is what keeps that from turning into full-screen fog:
+// past a couple of paper-diagonals from the ignition point, smoke is masked
+// out entirely regardless of how long the burn has been running.
+vec4 smokeAt(vec2 auv, float dist, float front) {
+  float age = -dist;
+  float envelope = smoothstep(0.0, 0.04, age);
+  vec2 driftUv = auv * 5.0 + vec2(0.6, -1.0) * (age + uProgress * 0.6) + uSeed * 23.0;
+  float wisp = fbm2(driftUv);
+  wisp = smoothstep(0.35, 0.75, wisp);
+  float smokeAlpha = envelope * wisp * 0.55;
+
+  float smokeReach = 1.8;
+  float reachMask = 1.0 - smoothstep(smokeReach * 0.6, smokeReach, front);
+  smokeAlpha *= reachMask;
+
+  // Only smoke gets an explicit end fade, and only right at the very end —
+  // char is left alone, since it already burns down to fully transparent on
+  // its own as the front sweeps past. Fading the whole scene together,
+  // including paper that had already fully burnt away, read as the picture
+  // itself dissolving rather than the fire still working — smoke is the
+  // only thing here that doesn't clear on its own.
+  float smokeFade = smoothstep(uFinishAt * 0.85, uFinishAt, uProgress);
+  smokeAlpha *= 1.0 - smokeFade;
+
+  return vec4(0.5, 0.49, 0.47, smokeAlpha);
+}
+
 void main() {
   vec2 uv = gl_FragCoord.xy / uResolution;
-  float aspect = uResolution.x / uResolution.y;
-  vec2 auv = vec2(uv.x * aspect, uv.y);
-  vec2 origin = vec2(uOrigin.x * aspect, uOrigin.y);
+
+  // Remap into the paper's own 0..1 space (matching exactly what `uv` was
+  // before this canvas grew to cover the whole viewport) — this extends
+  // linearly outside uRect rather than clamping, so distances computed from
+  // it stay physically continuous right across the paper's edges.
+  vec2 rectMin = uRect.xy;
+  vec2 rectMax = uRect.zw;
+  vec2 texUv = (uv - rectMin) / (rectMax - rectMin);
+  bool insideRect = texUv.x >= 0.0 && texUv.x <= 1.0 && texUv.y >= 0.0 && texUv.y <= 1.0;
+
+  float rectAspect =
+    ((rectMax.x - rectMin.x) * uResolution.x) / ((rectMax.y - rectMin.y) * uResolution.y);
+  vec2 auv = vec2(texUv.x * rectAspect, texUv.y);
+  vec2 origin = vec2(uOrigin.x * rectAspect, uOrigin.y);
 
   // Radial distance from the random ignition point, normalized against the
-  // full diagonal so progress reaches every corner regardless of where the
-  // origin happens to land — this is what gives the burn an expanding front
-  // from a single point rather than a sweep from one edge to another.
-  float diag = length(vec2(aspect, 1.0));
+  // paper's own diagonal so progress reaches every corner of it regardless
+  // of where the origin happens to land — this is what gives the burn an
+  // expanding front from a single point rather than a sweep from one edge
+  // to another.
+  float diag = length(vec2(rectAspect, 1.0));
   float front = length(auv - origin) / diag;
 
   // A coarse layer roughens the front's shape; a finer layer breaks up its
@@ -72,6 +127,17 @@ void main() {
   // Positive: not yet burned. Negative: already gone.
   float dist = (front + roughness) - uProgress;
   float edgeWidth = 0.075;
+
+  if (!insideRect) {
+    // Nothing to burn out here — just smoke that's already drifted this
+    // far, or empty space it hasn't reached yet.
+    if (dist > 0.0) {
+      gl_FragColor = vec4(0.0);
+      return;
+    }
+    gl_FragColor = smokeAt(auv, dist, front);
+    return;
+  }
 
   // Curl: just ahead of the front, warp the sampled texture coordinate
   // toward the ignition point and darken slightly, so the paper reads as
@@ -86,7 +152,7 @@ void main() {
   vec2 curlPerp = vec2(-curlDir.y, curlDir.x);
   float wobble = (fbm2(auv * 6.0 + uSeed * 19.0) - 0.5) * 0.6;
   vec2 curlOffset = (-curlDir + curlPerp * wobble) * curlT * 0.045;
-  vec2 sampleUv = clamp(uv + vec2(curlOffset.x / aspect, curlOffset.y), 0.0, 1.0);
+  vec2 sampleUv = clamp(texUv + vec2(curlOffset.x / rectAspect, curlOffset.y), 0.0, 1.0);
 
   vec4 src = texture2D(uTexture, sampleUv);
   src.rgb *= 1.0 - curlT * 0.35;
@@ -120,30 +186,17 @@ void main() {
   vec3 charColor = mix(vec3(0.05, 0.03, 0.02), vec3(0.0), charT);
   float charAlpha = src.a * (1.0 - smoothstep(0.0, 1.0, charT));
 
-  // Smoke: a thick wispy trail that rises just behind the char front and
-  // stays fully present — no per-pixel decay — so every burn visibly leaves
-  // smoke hanging in the air instead of watching it dissipate mid-animation.
-  // `age` is how far past the front this pixel sits, used only to fade the
-  // smoke *in* quickly once it ignites, not to fade it back out again.
-  float age = -dist;
-  float envelope = smoothstep(0.0, 0.04, age);
-  vec2 driftUv = auv * 5.0 + vec2(0.6, -1.0) * (age + uProgress * 0.6) + uSeed * 23.0;
-  float wisp = fbm2(driftUv);
-  wisp = smoothstep(0.35, 0.75, wisp);
-  float smokeAlpha = envelope * wisp * 0.55;
-  vec3 smokeColor = vec3(0.5, 0.49, 0.47);
-
-  // Only smoke gets an explicit end fade, and only right at the very end —
-  // char is left alone, since it already burns down to fully transparent on
-  // its own as the front sweeps past (see charAlpha above). Fading the whole
-  // scene together, including paper that had already fully burnt away, read
-  // as the picture itself dissolving rather than the fire still working —
-  // smoke is the only thing here that doesn't clear on its own.
-  float smokeFade = smoothstep(uFinishAt * 0.85, uFinishAt, uProgress);
-  smokeAlpha *= 1.0 - smokeFade;
-
-  vec3 finalColor = mix(charColor, smokeColor, smokeAlpha);
-  float finalAlpha = max(charAlpha, smokeAlpha);
+  // Proper (non-premultiplied) "smoke over char" compositing rather than a
+  // plain mix() weighted only by smoke.a — that would keep pulling the
+  // result toward charColor even once charAlpha has faded to ~0, leaving a
+  // visible dark seam right at the paper's edge where this blends against
+  // the outside-rect branch's pure smoke (see smokeAt/main above), which
+  // has no char layer to tint it.
+  vec4 smoke = smokeAt(auv, dist, front);
+  float finalAlpha = smoke.a + charAlpha * (1.0 - smoke.a);
+  vec3 finalColor = finalAlpha > 0.0001
+    ? (smoke.rgb * smoke.a + charColor * charAlpha * (1.0 - smoke.a)) / finalAlpha
+    : vec3(0.0);
 
   gl_FragColor = vec4(finalColor, finalAlpha);
 }

--- a/src/test/mockWebGLContext.ts
+++ b/src/test/mockWebGLContext.ts
@@ -42,6 +42,7 @@ export function createMockGLContext() {
     uniform1f: vi.fn(),
     uniform2f: vi.fn(),
     uniform2fv: vi.fn(),
+    uniform4f: vi.fn(),
     uniform1i: vi.fn(),
 
     // Textures.


### PR DESCRIPTION
## Summary
- Hawk/Dove mirrored a second wing above and below the shoulder, which reads as a dorsal/top-down view rather than a true side profile — each now uses a single wing swept up from the shoulder, matching how the near and far wing actually overlap when a bird is seen from the side.
- The burn-close transition's canvas was sized and clipped to the résumé modal's own box (which also has `overflow: hidden`), so its smoke could never drift past the paper's edges, and the whole effect finished in under 3 seconds.
  - The canvas is now a viewport-covering, `pointer-events: none` overlay (a sibling of `.modal` rather than a child of it), told where the résumé actually sits via a new `uRect` uniform, so the fire/paper still burns in exactly the same place while smoke can now drift beyond it — spatially capped so it billows out rather than fogging the whole screen.
  - Smoke also now lingers far longer before the final fade (`finishAt` raised from 1.8 to 9).
  - Fixed a compositing bug found along the way: once the char fully dissolved, the shader was still blending toward the char color before mixing in smoke, leaving a faint seam at the paper's edge.

## Test plan
- [x] `tsc --noEmit`, `eslint .`, `prettier --check .`, `vite build` all pass
- [x] `vitest run` — 97 tests passing
- [x] Verified the shader compiles/links and the `uRect` uniform correctly identifies the résumé's on-screen box (direct solid-color overlay test)
- [x] Verified the fire/char/ember still renders correctly and stays confined to the résumé's rect
- [x] Verified the bird silhouette reads as a side profile across multiple animation frames

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NMtuu5EBhZVwHHdYMFa9dm)_